### PR TITLE
Removing CE cacher dependency

### DIFF
--- a/cluster-operator/content_sets.yml
+++ b/cluster-operator/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/cluster-operator/image.yaml
+++ b/cluster-operator/image.yaml
@@ -22,9 +22,13 @@ modules:
   install:
     - name: cluster-operator
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 artifacts:
-  - path: cluster-operator-0.8.1.redhat-00001.jar
-    md5: 5420042711c2bd43ce9a095bc6a2347f
+  - md5: 5420042711c2bd43ce9a095bc6a2347f
     name: cluster-operator.jar
 
 run:

--- a/entity-operator-stunnel/content_sets.yml
+++ b/entity-operator-stunnel/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/entity-operator-stunnel/image.yaml
+++ b/entity-operator-stunnel/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: entity-operator-stunnel
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 run:
   workdir: "/opt/stunnel"
   user: 185

--- a/java-base/content_sets.yml
+++ b/java-base/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/java-base/image.yaml
+++ b/java-base/image.yaml
@@ -24,13 +24,14 @@ modules:
     - name: modules
       path: modules
   install:
-      - name: dynamic-resources
-      - name: os-java-run
-      - name: os-javabase-install
+    - name: dynamic-resources
+    - name: os-java-run
+    - name: os-javabase-install
 
 packages:
-  repositories:
-    - jboss-os
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
   install:
     - openssl
     - nmap-ncat

--- a/kafka-base/content_sets.yml
+++ b/kafka-base/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-base/image.yaml
+++ b/kafka-base/image.yaml
@@ -26,8 +26,9 @@ envs:
     value: "0.1.0"
 
 packages:
-  repositories:
-    - jboss-os
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
   install:
     - openssl
     - gettext
@@ -41,11 +42,9 @@ modules:
     - name: kafka-base
 
 artifacts:
-  - path: kafka-2.0.0.redhat-00003.tar.gz
-    md5: 5e35768a5b0ccb13bd3f34643f7135aa
+  - md5: 5e35768a5b0ccb13bd3f34643f7135aa
     name: kafka.tar.gz
-  - path: jmx_prometheus_javaagent-0.10.0.redhat-2.jar
-    md5: 89e83b40f70c9ca43a409e5b485555bc
+  - md5: 89e83b40f70c9ca43a409e5b485555bc
     name: jmx_prometheus_javaagent.jar
 
 run:

--- a/kafka-connect-s2i/content_sets.yml
+++ b/kafka-connect-s2i/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-connect-s2i/image.yaml
+++ b/kafka-connect-s2i/image.yaml
@@ -25,6 +25,11 @@ modules:
   install:
     - name: kafka-connect-s2i
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 envs:
   - name: "S2I_HOME"
     value: "/opt/s2i"

--- a/kafka-connect/content_sets.yml
+++ b/kafka-connect/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-connect/image.yaml
+++ b/kafka-connect/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: kafka-connect
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 ports:
   - value: 8083
 

--- a/kafka-init/content_sets.yml
+++ b/kafka-init/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-init/image.yaml
+++ b/kafka-init/image.yaml
@@ -25,9 +25,13 @@ modules:
   install:
     - name: kafka-init
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 artifacts:
-  - path: kafka-init-0.8.1.redhat-00001.jar
-    md5: 4a9990965bbaf1b7c956d35b413f3b91
+  - md5: 4a9990965bbaf1b7c956d35b413f3b91
     name: kafka-init.jar
 
 run:

--- a/kafka-mirror-maker/content_sets.yml
+++ b/kafka-mirror-maker/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-mirror-maker/image.yaml
+++ b/kafka-mirror-maker/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: kafka-mirror-maker
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 run:
   user: 185
   cmd:

--- a/kafka-stunnel/content_sets.yml
+++ b/kafka-stunnel/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka-stunnel/image.yaml
+++ b/kafka-stunnel/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: kafka-stunnel
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 run:
   workdir: "/opt/stunnel"
   user: 185

--- a/kafka/content_sets.yml
+++ b/kafka/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/kafka/image.yaml
+++ b/kafka/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: kafka
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 ports:
   - value: 9091
   - value: 9092

--- a/stunnel-base/content_sets.yml
+++ b/stunnel-base/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/stunnel-base/image.yaml
+++ b/stunnel-base/image.yaml
@@ -20,8 +20,9 @@ envs:
     value: "/opt/stunnel"
 
 packages:
-  repositories:
-    - jboss-os
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
   install:
     - stunnel
     - hostname

--- a/topic-operator/content_sets.yml
+++ b/topic-operator/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/topic-operator/image.yaml
+++ b/topic-operator/image.yaml
@@ -21,9 +21,13 @@ modules:
   install:
     - name: topic-operator
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 artifacts:
-  - path: topic-operator-0.8.1.redhat-00001.jar
-    md5: 3a377582f19add6afe5f9f6d862ba46f
+  - md5: 3a377582f19add6afe5f9f6d862ba46f
     name: topic-operator.jar
 
 run:

--- a/user-operator/content_sets.yml
+++ b/user-operator/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/user-operator/image.yaml
+++ b/user-operator/image.yaml
@@ -25,9 +25,13 @@ modules:
   install:
     - name: user-operator
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 artifacts:
-  - path: user-operator-0.8.1.redhat-00001.jar
-    md5: 8d8e638d7cc4190885a78909546729b3
+  - md5: 8d8e638d7cc4190885a78909546729b3
     name: user-operator.jar
 
 run:

--- a/zookeeper-stunnel/content_sets.yml
+++ b/zookeeper-stunnel/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/zookeeper-stunnel/image.yaml
+++ b/zookeeper-stunnel/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: stunnel-zookeeper
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 run:
   workdir: "/opt/stunnel"
   user: 185

--- a/zookeeper/content_sets.yml
+++ b/zookeeper/content_sets.yml
@@ -1,3 +1,0 @@
----
-x86_64:
-- rhel-7-server-rpms

--- a/zookeeper/image.yaml
+++ b/zookeeper/image.yaml
@@ -21,6 +21,11 @@ modules:
   install:
     - name: zookeeper
 
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+
 ports:
   - value: 2181
   - value: 2888


### PR DESCRIPTION
In the event that a CVE rolls through after CE services shutdown and before our next release and Freshmaker fails, we should be prepared to to build these images manually just in case

Cekit version 2.2.1 removes our dependency on the CE cacher and requires some simple syntax changes to our image descriptor files

1. Removing "path" from artifact declarations
2  Linking/embedding content_sets.yml into our image descriptor files 

 With these changes, cekit will pull AMQ Streams artifacts directly from brew using the md5 checksums, giving us a little bit more flexibility