### PR TITLE
Removing CE base image dependency

### DIFF
--- a/cluster-operator/image.yaml
+++ b/cluster-operator/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-clusteroperator-openshift
+name: amqstreams-1/amqstreams11-clusteroperator-openshift
 description: "AMQ Streams image for the Cluster Operator"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-javabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-javabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-clusteroperator-openshift-container"
+    value: "amqstreams11-clusteroperator-openshift-container"
   - name: "io.k8s.description"
     value: "Cluster Operator component for managing a Kafka Cluster"
   - name: "io.k8s.display-name"
@@ -40,4 +40,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-clusteroperator-openshift-rhel-7
+    branch: rh-amqstreams-1.1-clusteroperator-openshift-rhel-7

--- a/entity-operator-stunnel/image.yaml
+++ b/entity-operator-stunnel/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-entityoperatorstunnel-openshift
+name: amqstreams-1/amqstreams11-entityoperatorstunnel-openshift
 description: "AMQ Streams image for Entity Operator Stunnel sidecar"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-stunnelbase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-stunnelbase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-entityoperatorstunnel-openshift-container"
+    value: "amqstreams11-entityoperatorstunnel-openshift-container"
   - name: "io.k8s.description"
     value: "Image for Entity Operator Stunnel sidecar"
   - name: "io.k8s.display-name"
@@ -35,4 +35,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-entityoperatorstunnel-openshift-rhel-7
+    branch: rh-amqstreams-1.1-entityoperatorstunnel-openshift-rhel-7

--- a/java-base/image.yaml
+++ b/java-base/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-javabase-openshift
+name: amqstreams-1/amqstreams11-javabase-openshift
 description: "AMQ Streams base image for Java based components"
-version: "1.0.0"
-from: jboss/openjdk18-rhel7:1.1
+version: "1.1.0"
+from: rhel7:7-released
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-javabase-openshift-container"
+    value: "amqstreams11-javabase-openshift-container"
   - name: "io.k8s.description"
     value: "Base image for Java based components"
   - name: "io.k8s.display-name"
@@ -19,11 +19,14 @@ modules:
   repositories:
     - name: cct_module
       git:
-          url: https://github.com/jboss-openshift/cct_module.git
-          ref: sprint-22
+        url: https://github.com/jboss-openshift/cct_module.git
+        ref: master
     - name: modules
       path: modules
   install:
+    - name: jboss.container.user
+    - name: jboss.container.openjdk.jdk
+      version: "8"
     - name: dynamic-resources
     - name: os-java-run
     - name: os-javabase-install
@@ -40,4 +43,4 @@ packages:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-javabase-openshift-rhel-7
+    branch: rh-amqstreams-1.1-javabase-openshift-rhel-7

--- a/kafka-base/image.yaml
+++ b/kafka-base/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkabase-openshift
+name: amqstreams-1/amqstreams11-kafkabase-openshift
 description: "AMQ Streams base image for Kafka and Zookeeper"
-version: "1.0.0"
-from: jboss/openjdk18-rhel7:1.1
+version: "1.1.0"
+from: rhel7:7-released
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkabase-openshift-container"
+    value: "amqstreams11-kafkabase-openshift-container"
   - name: "io.k8s.description"
     value: "Base image for Apache Kafka and Zookeeper"
   - name: "io.k8s.display-name"
@@ -21,7 +21,7 @@ envs:
   - name: "SCALA_VERSION"
     value: "2.12"
   - name: "KAFKA_VERSION"
-    value: "1.0.1"
+    value: "2.0.0"
   - name: "JMX_EXPORTER_VERSION"
     value: "0.1.0"
 
@@ -37,8 +37,16 @@ packages:
 
 modules:
   repositories:
-    - path: modules
+    - name: cct_module
+      git:
+        url: https://github.com/jboss-openshift/cct_module.git
+        ref: master
+    - name: modules
+      path: modules
   install:
+    - name: jboss.container.user
+    - name: jboss.container.openjdk.jdk
+      version: "8"
     - name: kafka-base
 
 artifacts:
@@ -53,4 +61,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkabase-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkabase-openshift-rhel-7

--- a/kafka-connect-s2i/image.yaml
+++ b/kafka-connect-s2i/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkaconnects2i-openshift
+name: amqstreams-1/amqstreams11-kafkaconnects2i-openshift
 description: "AMQ Streams image for Kafka Connect with S2I"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-kafkaconnect-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-kafkaconnect-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkaconnects2i-openshift-container"
+    value: "amqstreams11-kafkaconnects2i-openshift-container"
   - name: "io.k8s.description"
     value: "A framework for scalably and reliably connecting Apache Kafka with external systems with third party connectors support via S2I"
   - name: "io.k8s.display-name"
@@ -42,4 +42,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkaconnects2i-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkaconnects2i-openshift-rhel-7

--- a/kafka-connect/image.yaml
+++ b/kafka-connect/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkaconnect-openshift
+name: amqstreams-1/amqstreams11-kafkaconnect-openshift
 description: "AMQ Streams image for Kafka Connect"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-kafkabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-kafkabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkaconnect-openshift-container"
+    value: "amqstreams11-kafkaconnect-openshift-container"
   - name: "io.k8s.description"
     value: "A framework for scalably and reliably connecting Apache Kafka with external systems"
   - name: "io.k8s.display-name"
@@ -37,4 +37,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkaconnect-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkaconnect-openshift-rhel-7

--- a/kafka-init/image.yaml
+++ b/kafka-init/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkainit-openshift
+name: amqstreams-1/amqstreams11-kafkainit-openshift
 description: "AMQ Streams base image for Kafka init"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-javabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-javabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkainit-openshift-container"
+    value: "amqstreams11-kafkainit-openshift-container"
   - name: "io.k8s.description"
     value: "Image for Kafka init"
   - name: "io.k8s.display-name"
@@ -42,4 +42,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkainit-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkainit-openshift-rhel-7

--- a/kafka-mirror-maker/image.yaml
+++ b/kafka-mirror-maker/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkamirrormaker-openshift
+name: amqstreams-1/amqstreams11-kafkamirrormaker-openshift
 description: "AMQ Streams image for Kafka"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-kafkabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-kafkabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkamirrormaker-openshift-container"
+    value: "amqstreams11-kafkamirrormaker-openshift-container"
   - name: "io.k8s.description"
     value: "A reliable and fault tolerant stream processing platform"
   - name: "io.k8s.display-name"
@@ -34,4 +34,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkamirrormaker-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkamirrormaker-openshift-rhel-7

--- a/kafka-stunnel/image.yaml
+++ b/kafka-stunnel/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafkastunnel-openshift
+name: amqstreams-1/amqstreams11-kafkastunnel-openshift
 description: "AMQ Streams image for Kafka Stunnel sidecar"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-stunnelbase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-stunnelbase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafkastunnel-openshift-container"
+    value: "amqstreams11-kafkastunnel-openshift-container"
   - name: "io.k8s.description"
     value: "Image for Kafka Stunnel sidecar"
   - name: "io.k8s.display-name"
@@ -35,4 +35,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafkastunnel-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafkastunnel-openshift-rhel-7

--- a/kafka/image.yaml
+++ b/kafka/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-kafka-openshift
+name: amqstreams-1/amqstreams11-kafka-openshift
 description: "AMQ Streams image for Kafka"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-kafkabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-kafkabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-kafka-openshift-container"
+    value: "amqstreams11-kafka-openshift-container"
   - name: "io.k8s.description"
     value: "A reliable and fault tolerant stream processing platform"
   - name: "io.k8s.display-name"
@@ -39,4 +39,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-kafka-openshift-rhel-7
+    branch: rh-amqstreams-1.1-kafka-openshift-rhel-7

--- a/stunnel-base/image.yaml
+++ b/stunnel-base/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-stunnelbase-openshift
+name: amqstreams-1/amqstreams11-stunnelbase-openshift
 description: "AMQ Streams base image for Stunnel sidecar images"
-version: "1.0.0"
-from: jboss/base-rhel7:1.1
+version: "1.1.0"
+from: rhel7:7-released
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-stunnelbase-openshift-container"
+    value: "amqstreams11-stunnelbase-openshift-container"
   - name: "io.k8s.description"
     value: "Base image for Stunnel sidecar images"
   - name: "io.k8s.display-name"
@@ -29,8 +29,14 @@ packages:
 
 modules:
   repositories:
-    - path: modules
+    - name: cct_module
+      git:
+        url: https://github.com/jboss-openshift/cct_module.git
+        ref: master
+    - name: modules
+      path: modules
   install:
+    - name: jboss.container.user
     - name: stunnel-base
 
 run:
@@ -39,4 +45,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-stunnelbase-openshift-rhel-7
+    branch: rh-amqstreams-1.1-stunnelbase-openshift-rhel-7

--- a/topic-operator/image.yaml
+++ b/topic-operator/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-topicoperator-openshift
+name: amqstreams-1/amqstreams11-topicoperator-openshift
 description: "AMQ Streams image for the Topic Operator"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-javabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-javabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-topicoperator-openshift-container"
+    value: "amqstreams11-topicoperator-openshift-container"
   - name: "io.k8s.description"
     value: "Topic Operator component for handling Kafka topics"
   - name: "io.k8s.display-name"
@@ -39,4 +39,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-topicoperator-openshift-rhel-7
+    branch: rh-amqstreams-1.1-topicoperator-openshift-rhel-7

--- a/user-operator/image.yaml
+++ b/user-operator/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-useroperator-openshift
+name: amqstreams-1/amqstreams11-useroperator-openshift
 description: "AMQ Streams image for User Operator"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-javabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-javabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-useroperator-openshift-container"
+    value: "amqstreams11-useroperator-openshift-container"
   - name: "io.k8s.description"
     value: "Image for User Operator"
   - name: "io.k8s.display-name"
@@ -43,4 +43,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-useroperator-openshift-rhel-7
+    branch: rh-amqstreams-1.1-useroperator-openshift-rhel-7

--- a/zookeeper-stunnel/image.yaml
+++ b/zookeeper-stunnel/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-zookeeperstunnel-openshift
+name: amqstreams-1/amqstreams11-zookeeperstunnel-openshift
 description: "AMQ Streams image for Zookeeper Stunnel sidecar"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-stunnelbase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-stunnelbase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-zookeeperstunnel-openshift-container"
+    value: "amqstreams11-zookeeperstunnel-openshift-container"
   - name: "io.k8s.description"
     value: "Image for Zookeeper Stunnel sidecar"
   - name: "io.k8s.display-name"
@@ -35,4 +35,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-zookeeperstunnel-openshift-rhel-7
+    branch: rh-amqstreams-1.1-zookeeperstunnel-openshift-rhel-7

--- a/zookeeper/image.yaml
+++ b/zookeeper/image.yaml
@@ -1,13 +1,13 @@
 schema_version: 1
 
-name: amqstreams-1/amqstreams10-zookeeper-openshift
+name: amqstreams-1/amqstreams11-zookeeper-openshift
 description: "AMQ Streams image for Zookeeper"
-version: "1.0.0"
-from: amqstreams-1/amqstreams10-kafkabase-openshift:1.0.0
+version: "1.1.0"
+from: amqstreams-1/amqstreams11-kafkabase-openshift:1.1.0
 
 labels:
   - name: "com.redhat.component"
-    value: "amqstreams10-zookeeper-openshift-container"
+    value: "amqstreams11-zookeeper-openshift-container"
   - name: "io.k8s.description"
     value: "A centralized service for distributed systems to a hierarchical key-value store"
   - name: "io.k8s.display-name"
@@ -40,4 +40,4 @@ run:
 osbs:
   repository:
     name: containers/amqstreams-1
-    branch: rh-amqstreams-1.0-zookeeper-openshift-rhel-7
+    branch: rh-amqstreams-1.1-zookeeper-openshift-rhel-7


### PR DESCRIPTION
Switched to amqstream11-dev branch for AMQ Streams 1.1 development

This PR:
1. Adjusts image names/version according to target release: 1.1.0
2. Moves all AMQ Streams images off of Cloud Enablement's (CE) deprecated base images "jboss-base" and "jboss-openjdk" ( Issue: #59 )
