### PR TITLE
Fix boolean value in operator descriptor file

### DIFF
--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -17,7 +17,7 @@ labels:
   - name: "licenses"
     value: "/root/licenses"
   - name: "com.redhat.delivery.appregistry"
-    value: true
+    value: "true"
 
 envs:
   - name: "STRIMZI_HOME"


### PR DESCRIPTION
This PR fixes the boolean value for the label related to the appregistry. Without it, the build fails with:

```
[ppatiern@new-host-3 operator]$ cekit build
2019-06-17 09:16:06,447 cekit        INFO     Generating files for docker engine.
validation.invalid
 --- All found errors ---
["Value 'True' is not of type 'str'. Path: '/value'"]
2019-06-17 09:16:06,459 cekit        ERROR    Cannot validate schema: Label
```