### PR TITLE
Applied renaming for Kafka images removing the period in the version

### DIFF
--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -29,29 +29,29 @@ spec:
         - name: STRIMZI_OPERATION_TIMEOUT_MS
           value: "300000"
         - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
-          value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+          value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-          value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+          value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
-          value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+          value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
-          value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+          value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_KAFKA_IMAGES
           value: |
-            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_KAFKA_CONNECT_IMAGES
           value: |
-            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
           value: |
-            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+            2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
           value: |
-            2.1.0=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+            2.1.0=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+            2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
         - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
           value: registry.redhat.io/amq7/amq-streams-operator:1.2.0
         - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE

--- a/kafka/kafka-2.1.1/help.md
+++ b/kafka/kafka-2.1.1/help.md
@@ -1,4 +1,4 @@
-% amq7/amq-streams-kafka-2.1 (1) Container Image Pages
+% amq7/amq-streams-kafka-21 (1) Container Image Pages
 
 # NAME
 

--- a/kafka/kafka-2.1.1/image.yaml
+++ b/kafka/kafka-2.1.1/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: amq7/amq-streams-kafka-2.1
+name: amq7/amq-streams-kafka-21
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect and Mirror Maker"
 version: "1.2.0"
 from: rhel7:7-released
@@ -25,7 +25,7 @@ envs:
   - name: "STRIMZI_VERSION"
     value: "0.12.0"
   - name: "COM_REDHAT_COMPONENT"
-    value: "amqstreams12-kafkabase-21-openshift-container"
+    value: "amqstreams12-kafka-21-openshift-container"
 
 modules:
   repositories:

--- a/kafka/kafka-2.2.1/help.md
+++ b/kafka/kafka-2.2.1/help.md
@@ -1,4 +1,4 @@
-% amq7/amq-streams-kafka-2.2 (1) Container Image Pages
+% amq7/amq-streams-kafka-22 (1) Container Image Pages
 
 # NAME
 

--- a/kafka/kafka-2.2.1/image.yaml
+++ b/kafka/kafka-2.2.1/image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-name: amq7/amq-streams-kafka-2.2
+name: amq7/amq-streams-kafka-22
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect and Mirror Maker"
 version: "1.2.0"
 from: rhel7:7-released
@@ -25,7 +25,7 @@ envs:
   - name: "STRIMZI_VERSION"
     value: "0.12.0"
   - name: "COM_REDHAT_COMPONENT"
-    value: "amqstreams12-kafkabase-22-openshift-container"
+    value: "amqstreams12-kafka-22-openshift-container"
 
 modules:
   repositories:

--- a/operator/modules/olm/manifests/amq-streams.v1.2.0.clusterserviceversion.yaml
+++ b/operator/modules/olm/manifests/amq-streams.v1.2.0.clusterserviceversion.yaml
@@ -670,29 +670,29 @@ spec:
                 - name: STRIMZI_OPERATION_TIMEOUT_MS
                   value: "300000"
                 - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                  value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                  value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                  value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                  value: registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_KAFKA_IMAGES
                   value: |
-                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_KAFKA_CONNECT_IMAGES
                   value: |
-                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
                   value: |
-                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                    2.1.1=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
                   value: |
-                    2.1.0=registry.redhat.io/amq7/amq-streams-kafka-2.1:1.2.0
-                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-2.2:1.2.0
+                    2.1.0=registry.redhat.io/amq7/amq-streams-kafka-21:1.2.0
+                    2.2.1=registry.redhat.io/amq7/amq-streams-kafka-22:1.2.0
                 - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
                   value: registry.redhat.io/amq7/amq-streams-operator:1.2.0
                 - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE


### PR DESCRIPTION
Changes about new Kafka image names and fix for #106 as well.