### PR TITLE
Migration to minimal Universal Base Image (ubi7-minimal)

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq7/amq-streams-bridge
 description: "AMQ Streams image for running the Apache Kafka bridge"
 version: "1.2.0"
-from: rhel7:7-released
+from: ubi7-minimal:latest
 
 labels:
   - name: "com.redhat.component"
@@ -33,6 +33,7 @@ modules:
     - name: bridge
 
 packages:
+  manager: microdnf
   content_sets:
     x86_64:
       - rhel-7-server-rpms

--- a/kafka/kafka-2.1.1/image.yaml
+++ b/kafka/kafka-2.1.1/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq7/amq-streams-kafka-21
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect and Mirror Maker"
 version: "1.2.0"
-from: rhel7:7-released
+from: ubi7-minimal:latest
 
 labels:
   - name: "com.redhat.component"
@@ -32,6 +32,7 @@ modules:
       version: "2.1.1"
 
 packages:
+  manager: microdnf
   content_sets:
     x86_64:
       - rhel-7-server-rpms

--- a/kafka/kafka-2.2.1/image.yaml
+++ b/kafka/kafka-2.2.1/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq7/amq-streams-kafka-22
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect and Mirror Maker"
 version: "1.2.0"
-from: rhel7:7-released
+from: ubi7-minimal:latest
 
 labels:
   - name: "com.redhat.component"
@@ -32,6 +32,7 @@ modules:
       version: 2.2.1
 
 packages:
+  manager: microdnf
   content_sets:
     x86_64:
       - rhel-7-server-rpms

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq7/amq-streams-operator
 description: "AMQ Streams image for the Cluster, Topic, User Operators, and Kafka init"
 version: "1.2.0"
-from: rhel7:7-released
+from: ubi7-minimal:latest
 
 labels:
   - name: "com.redhat.component"
@@ -36,6 +36,7 @@ modules:
     - name: olm
 
 packages:
+  manager: microdnf
   content_sets:
     x86_64:
       - rhel-7-server-rpms


### PR DESCRIPTION
Images built and smoke tested. Cuts down the image size a little bit (~5MB) but meets the UBI7 requirement. We will be able to reduces the size of the images by removing unneeded dependencies added by cct_modules in future PRs