### PR TITLE
Remove cct modules dependency

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -27,9 +27,6 @@ modules:
       path: modules
   install:
     - name: jboss.container.user
-    - name: jboss.container.openjdk.jdk
-      version: "8"
-    - name: os-java-run
     - name: bridge
 
 packages:
@@ -38,6 +35,7 @@ packages:
     x86_64:
       - rhel-7-server-rpms
   install:
+    - java-1.8.0-openjdk-headless
     - openssl
     - nmap-ncat
     - hostname

--- a/kafka/kafka-2.1.1/image.yaml
+++ b/kafka/kafka-2.1.1/image.yaml
@@ -25,9 +25,6 @@ modules:
       path: ../modules
   install:
     - name: jboss.container.user
-    - name: jboss.container.openjdk.jdk
-      version: "8"
-    - name: os-java-run
     - name: kafka
       version: "2.1.1"
 
@@ -37,6 +34,7 @@ packages:
     x86_64:
       - rhel-7-server-rpms
   install:
+    - java-1.8.0-openjdk-headless
     - gettext
     - nmap-ncat
     - openssl

--- a/kafka/kafka-2.2.1/image.yaml
+++ b/kafka/kafka-2.2.1/image.yaml
@@ -25,9 +25,6 @@ modules:
       path: ../modules
   install:
     - name: jboss.container.user
-    - name: jboss.container.openjdk.jdk
-      version: "8"
-    - name: os-java-run
     - name: kafka
       version: 2.2.1
 
@@ -37,6 +34,7 @@ packages:
     x86_64:
       - rhel-7-server-rpms
   install:
+    - java-1.8.0-openjdk-headless
     - gettext
     - nmap-ncat
     - openssl

--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -18,9 +18,7 @@ mkdir /opt/prometheus/config
 cp -r ${SOURCES_DIR}/jmx_prometheus_javaagent.jar /opt/prometheus/jmx_prometheus_javaagent.jar
 cp -r ${SOURCES_DIR}/kafka-agent.jar ${KAFKA_HOME}/libs/
 
-chown -R jboss:root ${KAFKA_HOME}
 chmod -R 0755 ${KAFKA_HOME}
-chown -R jboss:root /opt/prometheus
 chmod -R 0755 /opt/prometheus
 
 cp -r ${SCRIPTS_DIR}/* ${KAFKA_HOME}/

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -29,9 +29,6 @@ modules:
       path: modules
   install:
     - name: jboss.container.user
-    - name: jboss.container.openjdk.jdk
-      version: "8"
-    - name: os-java-run
     - name: operator
     - name: olm
 
@@ -41,6 +38,7 @@ packages:
     x86_64:
       - rhel-7-server-rpms
   install:
+    - java-1.8.0-openjdk-headless
     - openssl
     - nmap-ncat
     - hostname


### PR DESCRIPTION
The installed cct_modules are adding a lot of unnecessary dependencies to our images e.g. openjdk-devel. By removing them we:

- Reduce the size of the images significantly ( ~100 MB )
- Reduce the the dependencies and CVE surface
- Reduce the complexity of image maintenance