### PR TITLE
Script updates for RC1

### DIFF
--- a/bridge/modules/bridge/module.yaml
+++ b/bridge/modules/bridge/module.yaml
@@ -10,9 +10,9 @@ envs:
     value: "amqstreams13-bridge-openshift-container"
 
 artifacts:
-  - md5: db38db497b7a337119e5cea55c0ef43e
+  - md5: 551de26d87ba3aa7f5f8d8ed90217584
     name: kafka-bridge.tar.gz
-  - md5: 8384576ef02897c5e36174444d73caf0
+  - md5: d3e169d746f9426e3794564162f0acee
     name: kafka-bridge-licenses.tar.gz
 
 execute:

--- a/kafka/modules/kafka/2.2.1/install.sh
+++ b/kafka/modules/kafka/2.2.1/install.sh
@@ -6,9 +6,10 @@ SOURCES_DIR=/tmp/artifacts
 LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
-tar xvfz "${SOURCES_DIR}/kafka.tar.gz" -C ${KAFKA_HOME} --strip-components=1
-
-cp -r ${SOURCES_DIR}/opentracing-kafka-client.jar ${KAFKA_HOME}/libs/
+# Copy contents of zip without the root dir
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka.zip
+mv ${TMP}/* ${KAFKA_HOME}/
 
 mkdir -p ${PRODUCT_LICENSE_DIR}
 cp ${KAFKA_HOME}/docs/licen*/* ${PRODUCT_LICENSE_DIR}

--- a/kafka/modules/kafka/2.2.1/module.yaml
+++ b/kafka/modules/kafka/2.2.1/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams13-kafka-22-openshift-container"
 
 artifacts:
-  - md5: 5f9620f6caee9eeb8bc819b6c14c6587
+  - md5: f093b064d419e0d9a81af68f1ef5e6cc
     name: kafka.zip
 
 modules:

--- a/kafka/modules/kafka/2.2.1/module.yaml
+++ b/kafka/modules/kafka/2.2.1/module.yaml
@@ -9,9 +9,7 @@ envs:
 
 artifacts:
   - md5: 5f9620f6caee9eeb8bc819b6c14c6587
-    name: kafka.tar.gz
-  - md5: d031d29790a62028a7bf3f4cd6707a7a
-    name: opentracing-kafka-client.jar
+    name: kafka.zip
 
 modules:
   install:

--- a/kafka/modules/kafka/2.3.0/install.sh
+++ b/kafka/modules/kafka/2.3.0/install.sh
@@ -6,9 +6,10 @@ SOURCES_DIR=/tmp/artifacts
 LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
-tar xvfz "${SOURCES_DIR}/kafka.tar.gz" -C ${KAFKA_HOME} --strip-components=1
-
-cp -r ${SOURCES_DIR}/opentracing-kafka-client.jar ${KAFKA_HOME}/libs/
+# Copy contents of zip without the root dir
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka.zip
+mv ${TMP}/* ${KAFKA_HOME}/
 
 mkdir -p ${PRODUCT_LICENSE_DIR}
 cp ${KAFKA_HOME}/docs/licen*/* ${PRODUCT_LICENSE_DIR}

--- a/kafka/modules/kafka/2.3.0/module.yaml
+++ b/kafka/modules/kafka/2.3.0/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams13-kafka-23-openshift-container"
 
 artifacts:
-  - md5: 6e3400b4455a4e6b6aee437fefd30a0f
+  - md5: b5b3555df5969d06a9510b52d9e415c7
     name: kafka.zip
 
 modules:

--- a/kafka/modules/kafka/2.3.0/module.yaml
+++ b/kafka/modules/kafka/2.3.0/module.yaml
@@ -9,9 +9,7 @@ envs:
 
 artifacts:
   - md5: 6e3400b4455a4e6b6aee437fefd30a0f
-    name: kafka.tar.gz
-  - md5: b23dc8079cf88ecf8ac81963b7063f37
-    name: opentracing-kafka-client.jar
+    name: kafka.zip
 
 modules:
   install:

--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -9,19 +9,11 @@ STUNNEL_DIR=${SCRIPT_DIR}/stunnel-scripts
 S2I_DIR=${SCRIPT_DIR}/s2i-scripts
 EXPORTER_DIR=${SCRIPT_DIR}/exporter-scripts
 
-mkdir -p $KAFKA_HOME/libs/
+mkdir $KAFKA_HOME
 mkdir $STUNNEL_HOME
 mkdir $S2I_HOME
 mkdir $KAFKA_EXPORTER_HOME
 mkdir -p -m g+rw /usr/local/var/run/
-
-cp -r ${SOURCES_DIR}/jmx_prometheus_javaagent.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/kafka-agent.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/mirror-maker-agent.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/tracing-agent.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/jaeger-client.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/opentracing-api.jar ${KAFKA_HOME}/libs/
-cp -r ${SOURCES_DIR}/opentracing-util.jar ${KAFKA_HOME}/libs/
 
 unzip -qo ${SOURCES_DIR}/kafka_exporter.zip -d ${KAFKA_EXPORTER_HOME}/
 

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -14,20 +14,6 @@ envs:
     value: "/opt/kafka-exporter"
 
 artifacts:
-  - md5: e63d0746c6b6f30ad9255487dfb5699c
-    name: kafka-agent.jar
-  - md5: 9d04e327041972c034d6cef389bcb2fc
-    name: mirror-maker-agent.jar
-  - md5: 8bd252d240b076d70f2460d1d2ff04e7
-    name: tracing-agent.jar
-  - md5: ad6855b57b61d58f345d2a041ed2db39
-    name: jmx_prometheus_javaagent.jar
-  - md5: e0b0e1296be40d5991a1a6fdb3d379f8
-    name: jaeger-client.jar
-  - md5: b7fccd4bfd8b2837cf867f6347467c18
-    name: opentracing-api.jar
-  - md5: d5473c38fbb28c0ef98183f75758d65a
-    name: opentracing-util.jar
   - md5: 620a927c5449bdf043813880f5395ab4
     name: kafka_exporter.zip
 

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -14,8 +14,8 @@ envs:
     value: "/opt/kafka-exporter"
 
 artifacts:
-  - md5: 620a927c5449bdf043813880f5395ab4
-    name: kafka_exporter.zip
+  - md5: f4a977d78320c89f597abeb275bfcbf5
+    name: kafka-exporter.zip
 
 execute:
   - script: install.sh

--- a/kafka/modules/kafka/base/scripts/kafka_connect_run.sh
+++ b/kafka/modules/kafka/base/scripts/kafka_connect_run.sh
@@ -37,7 +37,7 @@ fi
 
 # enabling Tracing agent (initializes Jaeger tracing) as Java agent
 if [ "$STRIMZI_TRACING" = "jaeger" ]; then
-    export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/tracing-agent.jar)=jaeger"
+    export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/tracing-agent*.jar)=jaeger"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/kafka/modules/kafka/base/scripts/kafka_mirror_maker_run.sh
+++ b/kafka/modules/kafka/base/scripts/kafka_mirror_maker_run.sh
@@ -52,7 +52,7 @@ export LOG_DIR="$KAFKA_HOME"
 
 # Enabling the Mirror Maker agent which monitors readiness / liveness
 rm /tmp/mirror-maker-ready /tmp/mirror-maker-alive 2> /dev/null
-export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/mirror-maker-agent.jar=/tmp/mirror-maker-ready:/tmp/mirror-maker-alive:${STRIMZI_READINESS_PERIOD:-10}:${STRIMZI_LIVENESS_PERIOD:-10}"
+export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/mirror-maker-agent*.jar)=/tmp/mirror-maker-ready:/tmp/mirror-maker-alive:${STRIMZI_READINESS_PERIOD:-10}:${STRIMZI_LIVENESS_PERIOD:-10}"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_MIRRORMAKER_METRICS_ENABLED" = "true" ]; then
@@ -61,7 +61,7 @@ fi
 
 # enabling Tracing agent (initializes Jaeger tracing) as Java agent
 if [ "$STRIMZI_TRACING" = "jaeger" ]; then
-  export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/tracing-agent.jar)=jaeger"
+  export KAFKA_OPTS="$KAFKA_OPTS -javaagent:$(ls $KAFKA_HOME/libs/tracing-agent*.jar)=jaeger"
 fi
 
 if [ -z "$KAFKA_HEAP_OPTS" -a -n "${DYNAMIC_HEAP_FRACTION}" ]; then

--- a/kafka/modules/kafka/base/scripts/kafka_run.sh
+++ b/kafka/modules/kafka/base/scripts/kafka_run.sh
@@ -23,7 +23,7 @@ if [ -z "$KAFKA_LOG4J_OPTS" ]; then
 fi
 
 rm /var/opt/kafka/kafka-ready /var/opt/kafka/zk-connected 2> /dev/null
-export KAFKA_OPTS="-javaagent:${KAFKA_HOME}/libs/kafka-agent.jar=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
+export KAFKA_OPTS="-javaagent:$(ls $KAFKA_HOME/libs/kafka-agent*.jar)=/var/opt/kafka/kafka-ready:/var/opt/kafka/zk-connected"
 
 # enabling Prometheus JMX exporter as Java agent
 if [ "$KAFKA_METRICS_ENABLED" = "true" ]; then

--- a/operator/modules/operator/module.yaml
+++ b/operator/modules/operator/module.yaml
@@ -10,15 +10,15 @@ envs:
     value: "amqstreams13-operator-container"
 
 artifacts:
-  - md5: 67234fc7d1a454d48194ffce0120266a
+  - md5: 4633beef08e89c3e39b89c987c66dee9
     name: cluster-operator-dist.zip
-  - md5: 565bf03e3a6d0160f0eadd003e927e5b
+  - md5: 8b2450519f5007eb7c424dc3bf016092
     name: topic-operator-dist.zip
-  - md5: 3e2843749b63a5e767d6b36e704b0b4a
+  - md5: 29820d915879afbef681f125d8fba4dd
     name: user-operator-dist.zip
-  - md5: 71c050c335e39948e07a994687a41d4d
+  - md5: 5c279a68c323a7d29bb0a4eb7904f39e
     name: kafka-init-dist.zip
-  - md5: 5d5e3b417987e440a5e48ac5b593b73a
+  - md5: 80bc79250b3c6ffc079335ec96281152
     name: strimzi-licenses.tar.gz
 
 execute:


### PR DESCRIPTION
Kafka and all of its dependencies are now provided to us in a single zip file. With this zip file, we only need to unpack its contents into ${KAFKA_HOME} directory and not worry about downloading and installing Kafka and all of its dependencies separately.

I have also updated some of the Kafka run scripts here and upstream to be able to handle jar names with versioned suffixes.