### PR TITLE
Add watch RBAC for CRBs and CRs

### DIFF
--- a/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/021-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -15,6 +15,7 @@ rules:
   - delete
   - patch
   - update
+  - watch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/operator/modules/olm/manifests/1.3.0/amq-streams.v1.3.0.clusterserviceversion.yaml
+++ b/operator/modules/olm/manifests/1.3.0/amq-streams.v1.3.0.clusterserviceversion.yaml
@@ -613,6 +613,7 @@ spec:
           - delete
           - patch
           - update
+          - watch
         - apiGroups:
           - storage.k8s.io
           resources:

--- a/operator/modules/olm/manifests/1.3.0/amq-streams.v1.3.0.clusterserviceversion.yaml
+++ b/operator/modules/olm/manifests/1.3.0/amq-streams.v1.3.0.clusterserviceversion.yaml
@@ -668,6 +668,7 @@ spec:
           - delete
           - patch
           - update
+          - watch
       deployments:
       - name: amq-streams-cluster-operator
         spec:


### PR DESCRIPTION
We need to have a `watch` RBAC right for deleting non-namespaced objects such as CRBs and CRs.