### PR TITLE
Change kafka.jar names to enable CPaaS processing

### DIFF
--- a/kafka/modules/kafka/2.2.1/install.sh
+++ b/kafka/modules/kafka/2.2.1/install.sh
@@ -7,8 +7,8 @@ LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
 # Copy contents of zip without the root dir
-TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka.zip | grep -oE '^[^/]+' | uniq)
-unzip ${SOURCES_DIR}/kafka.zip
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka-*.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka-*.zip
 mv ${TMP}/* ${KAFKA_HOME}/
 
 cp -r ${KAFKA_HOME}/bin/kafka_exporter ${KAFKA_EXPORTER_HOME}/

--- a/kafka/modules/kafka/2.2.1/module.yaml
+++ b/kafka/modules/kafka/2.2.1/module.yaml
@@ -9,7 +9,7 @@ envs:
 
 artifacts:
   - md5: a3cf63e7599b417bf9e10158c7e4034e
-    name: kafka.zip
+    name: kafka-22.zip
 
 modules:
   install:

--- a/kafka/modules/kafka/2.3.0/install.sh
+++ b/kafka/modules/kafka/2.3.0/install.sh
@@ -7,8 +7,8 @@ LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
 # Copy contents of zip without the root dir
-TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka.zip | grep -oE '^[^/]+' | uniq)
-unzip ${SOURCES_DIR}/kafka.zip
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka-*.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka-*.zip
 mv ${TMP}/* ${KAFKA_HOME}/
 
 cp -r ${KAFKA_HOME}/bin/kafka_exporter ${KAFKA_EXPORTER_HOME}/

--- a/kafka/modules/kafka/2.3.0/module.yaml
+++ b/kafka/modules/kafka/2.3.0/module.yaml
@@ -9,7 +9,7 @@ envs:
 
 artifacts:
   - md5: 2105cf17dd4573b50c2632510524eefa
-    name: kafka.zip
+    name: kafka-23.zip
 
 modules:
   install:


### PR DESCRIPTION
Changing the kafka.jar name used in the kafka-2.2.1 image and the kafka-2.3.0 image to "kafka-22.jar" and "kafka-23.jar" respectively so that CPaaS can differentiate between the jars in the CPaaS configuration files