### PR TITLE
Change bridge artifact packaging to zip

### DIFF
--- a/bridge/modules/bridge/install.sh
+++ b/bridge/modules/bridge/install.sh
@@ -17,8 +17,10 @@ tar -xvzf ${LICENSE_DIR}/kafka-bridge-licenses.tar.gz -C ${PRODUCT_LICENSE_DIR}
 # create destination folder of scripts, jars and config
 mkdir -p ${STRIMZI_HOME}
 
-# untar archive/artifact with bridge scripts and jars
-tar xvfz "${SOURCES_DIR}/kafka-bridge.tar.gz" -C ${STRIMZI_HOME} --strip-components=1
+# unzip archive/artifact with bridge scripts and jars
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka-bridge*.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka-bridge*.zip
+mv ${TMP}/* ${STRIMZI_HOME}/
 
 chmod -R 0755 ${STRIMZI_HOME}/bin
 chmod -R 0755 ${STRIMZI_HOME}/libs

--- a/bridge/modules/bridge/module.yaml
+++ b/bridge/modules/bridge/module.yaml
@@ -11,7 +11,7 @@ envs:
 
 artifacts:
   - md5: 80c0bbf8918e820c04a431a9813c8506
-    name: kafka-bridge.tar.gz
+    name: kafka-bridge.zip
   - md5: b11d53cee5d9f06c17c8aaae3d3c2fc5
     name: kafka-bridge-licenses.tar.gz
 


### PR DESCRIPTION
There is an extra root directory, "kafka-bridge-0.14.0.temporary-redhat-00012", included in the productized bridge zip (the other productized zips for strimzi do not have this extra directory, e.g. cluster-operator, user-operator, etc.). I have added some extra scripts to get around this, but we should probably remove this extra root directory in bridge zip at some point to follow the pattern of the other zip files