### PR TITLE
Update metadata image dist-git repo branch

### DIFF
--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -39,5 +39,5 @@ osbs:
       compose:
         pulp_repos: true
   repository:
-    name: containers/amqstreams-operator-dev-operator-metadata
+    name: containers/amqstreams-operator-prod-operator-metadata
     branch: amqstreams-1-rhel-7


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

Talking with the operator pipeline people a couple weeks ago where they said we are supposed to be using the *prod* dist-git branch while reserving the other branches for some future RCM workflow for handling multistream operator releases

No rush on this PR as it shouldn't matter which dist-git branch we build off of right now