### PR TITLE
Fixing SHAs and typos in OLM files

### DIFF
--- a/common/modules/olm/manifests/1.4.0/amq-streams.v1.4.0.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.4.0/amq-streams.v1.4.0.clusterserviceversion.yaml
@@ -286,7 +286,7 @@ metadata:
     categories: "Streaming & Messaging"
     certified: "false"
     description: Red Hat AMQ Streams is a massively scalable, distributed, and high performance data streaming platform based on Apache Kafka®.
-    containerImage: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+    containerImage: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
     repository: https://github.com/strimzi/strimzi-kafka-operator
     createdAt: 2020-02-10T10:00:00Z
     support: Red Hat
@@ -412,13 +412,13 @@ spec:
     supported: true
   relatedImages:
   - name: strimzi-cluster-operator
-    value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+    image: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
   - name: strimzi-kafka-23
-    value: registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:a358ca3145437a8b0a950399081c3e232de1309e39610429afe6c786002bbd91
+    image: registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:58907d2ce26a9c07f0da06ef0030d086164e83ab7a3c45a1fd52049eacf51d9a
   - name: strimzi-kafka-24
-    value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+    image: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
   - name: strimzi-bridge
-    value: registry.redhat.io/amq7/amq-streams-bridge-rhel7@sha256:022ad2207d77c501e8b735317df08ba471ca398d7eaea5d06e0833566b09d37f
+    image: registry.redhat.io/amq7/amq-streams-bridge-rhel7@sha256:022ad2207d77c501e8b735317df08ba471ca398d7eaea5d06e0833566b09d37f
   install:
     strategy: deployment
     spec:
@@ -764,7 +764,7 @@ spec:
               serviceAccountName: strimzi-cluster-operator
               containers:
               - name: cluster-operator
-                image: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+                image: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
                 imagePullPolicy: IfNotPresent
                 args:
                 - /opt/strimzi/bin/cluster_operator_run.sh
@@ -778,40 +778,40 @@ spec:
                 - name: STRIMZI_OPERATION_TIMEOUT_MS
                   value: "300000"
                 - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                  value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_KAFKA_IMAGES
                   value: |
-                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:a358ca3145437a8b0a950399081c3e232de1309e39610429afe6c786002bbd91
-                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:58907d2ce26a9c07f0da06ef0030d086164e83ab7a3c45a1fd52049eacf51d9a
+                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_KAFKA_CONNECT_IMAGES
                   value: |
-                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:a358ca3145437a8b0a950399081c3e232de1309e39610429afe6c786002bbd91
-                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:58907d2ce26a9c07f0da06ef0030d086164e83ab7a3c45a1fd52049eacf51d9a
+                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
                   value: |
-                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:a358ca3145437a8b0a950399081c3e232de1309e39610429afe6c786002bbd91
-                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:58907d2ce26a9c07f0da06ef0030d086164e83ab7a3c45a1fd52049eacf51d9a
+                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
                   value: |
-                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:a358ca3145437a8b0a950399081c3e232de1309e39610429afe6c786002bbd91
-                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                    2.3.0=registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:58907d2ce26a9c07f0da06ef0030d086164e83ab7a3c45a1fd52049eacf51d9a
+                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
                   value: |
-                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:13f74d1b5e16654fb556525db6433f87b9acd7ddf5faba1d46a3a9d83bddb310
+                    2.4.0=registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:f9ceca004f1b7dccb3b82d9a8027961f9fe4104e0ed69752c0bdd8078b4a1076
                 - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
                 - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
                 - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:f52f820aeaaccf88797e40f4c7fad5613c5f032348312858a3b3bf54695af736
+                  value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:4079eadd9a806adfbf3222f071c0498b17a6c54f9b8d199cf5af4961bcbdd83a
                 - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
                   value: registry.redhat.io/amq7/amq-streams-bridge-rhel7@sha256:022ad2207d77c501e8b735317df08ba471ca398d7eaea5d06e0833566b09d37f
                 - name: STRIMZI_LOG_LEVEL

--- a/common/modules/olm/manifests/1.4.1/amq-streams.v1.4.1.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.4.1/amq-streams.v1.4.1.clusterserviceversion.yaml
@@ -412,13 +412,13 @@ spec:
     supported: true
   relatedImages:
   - name: strimzi-cluster-operator
-    value: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:49206f4add46050cdd0da7cb74f1f767240892403695e9e7119f68784da545af
+    image: registry.redhat.io/amq7/amq-streams-rhel7-operator@sha256:49206f4add46050cdd0da7cb74f1f767240892403695e9e7119f68784da545af
   - name: strimzi-kafka-23
-    value: registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:f32bc062bcc1632aab60e253aec2833572171adb226712dc287444800f0ce1ce
+    image: registry.redhat.io/amq7/amq-streams-kafka-23-rhel7@sha256:f32bc062bcc1632aab60e253aec2833572171adb226712dc287444800f0ce1ce
   - name: strimzi-kafka-24
-    value: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:825b5eb37e8868f71861f78a973fd3891bef60b26c6e3e35662fc19887040b07
+    image: registry.redhat.io/amq7/amq-streams-kafka-24-rhel7@sha256:825b5eb37e8868f71861f78a973fd3891bef60b26c6e3e35662fc19887040b07
   - name: strimzi-bridge
-    value: registry.redhat.io/amq7/amq-streams-bridge-rhel7@sha256:a224012f5b28e3525a0a63a30dfc6975cb1f6e7ff09cdcfc33469fa1e1cfedaa
+    image: registry.redhat.io/amq7/amq-streams-bridge-rhel7@sha256:a224012f5b28e3525a0a63a30dfc6975cb1f6e7ff09cdcfc33469fa1e1cfedaa
   install:
     strategy: deployment
     spec:


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

When populating the SHAs for the 1.4.0 OLM files, I used the:

- incorrect brew builds
- incorrect field names for the `relatedImages` section

These files have now been corrected and verified by QE!