### PR TITLE
Add manifest config + fix podman build issue

### DIFF
--- a/bridge/modules/bridge/install.sh
+++ b/bridge/modules/bridge/install.sh
@@ -12,7 +12,7 @@ useradd -r -m -u 1001 -g 0 strimzi
 # untar the artifact containing license information
 mkdir -p ${PRODUCT_LICENSE_DIR}
 mv ${SOURCES_DIR}/kafka-bridge-licenses.tar.gz ${LICENSE_DIR}
-tar -xvzf ${LICENSE_DIR}/kafka-bridge-licenses.tar.gz -C ${PRODUCT_LICENSE_DIR}
+tar -xvzf ${LICENSE_DIR}/kafka-bridge-licenses.tar.gz -C ${PRODUCT_LICENSE_DIR} --no-same-owner
 
 # create destination folder of scripts, jars and config
 mkdir -p ${STRIMZI_HOME}

--- a/operator-metadata/dist-git-files/container.yaml
+++ b/operator-metadata/dist-git-files/container.yaml
@@ -1,0 +1,3 @@
+---
+operator_manifests:
+  manifests_dir: manifests

--- a/operator/modules/operator/install.sh
+++ b/operator/modules/operator/install.sh
@@ -14,7 +14,7 @@ useradd -r -m -u 1001 -g 0 strimzi
 # untar the artifact containing license information
 mkdir -p ${PRODUCT_LICENSE_DIR}
 mv ${SOURCES_DIR}/*.tar.gz ${LICENSE_DIR}
-tar -xvzf ${LICENSE_DIR}/*.tar.gz -C ${PRODUCT_LICENSE_DIR}
+tar -xvzf ${LICENSE_DIR}/*.tar.gz -C ${PRODUCT_LICENSE_DIR} --no-same-owner
 
 # create destination folder of scripts and jars
 mkdir -p ${STRIMZI_HOME}


### PR DESCRIPTION
This PR:
- Adds a new manifest configuration that is now required to run builds in OSBS
- Fixes tar user issue that was preventing images to be built locally with podman. More information can be found here [1]

[1] https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233

