### PR TITLE
Remove "tini" patch

### DIFF
--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -22,6 +22,13 @@ chmod -R 0755 ${KAFKA_HOME}
 # extract all the Kafka related scripts
 unzip ${SOURCES_DIR}/strimzi-kafka-scripts.zip -d ${SCRIPTS_DIR}
 
+# patch to remove "tini"
+FILES=$(find ${SCRIPTS_DIR} -type f -name "*.sh")
+for f in $FILES
+do
+  sed -i 's/\/usr\/bin\/tini -w -e 143 -- sh -c //' $f
+done
+
 # NOTE: kafka folder alredy contains the s2i (so no need for a specific cp command)
 cp -r ${SCRIPTS_DIR}/kafka/* ${KAFKA_HOME}/
 chmod -R 755 ${KAFKA_HOME}

--- a/operator/modules/operator/install.sh
+++ b/operator/modules/operator/install.sh
@@ -28,6 +28,13 @@ done
 # extract all the operator related scripts
 unzip ${SOURCES_DIR}/strimzi-operator-scripts.zip -d ${SCRIPTS_DIR}
 
+# patch to remove "tini"
+FILES=$(find ${SCRIPTS_DIR} -type f -name "*.sh")
+for f in $FILES
+do
+  sed -i 's/\/usr\/bin\/tini -w -e 143 -- //' $f
+done
+
 # copy module related scripts
 cp -r ${SCRIPTS_DIR}/* ${STRIMZI_HOME}/bin
 


### PR DESCRIPTION
This trivial PR adds a temporaty patch for removing "tini" usage on the packaged scripts until "tini" will be available to be installed as rpm.