### PR TITLE
Adding tini package

### DIFF
--- a/kafka/kafka-2.4.0/image.yaml
+++ b/kafka/kafka-2.4.0/image.yaml
@@ -28,6 +28,7 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - amq-streams-1-for-rhel-7-server-rpms
   install:
     - java-1.8.0-openjdk-headless
     - gettext
@@ -37,6 +38,7 @@ packages:
     - stunnel
     - net-tools
     - bind-utils
+    - tini
  
 run:
   user: 1001

--- a/kafka/kafka-2.5.0/image.yaml
+++ b/kafka/kafka-2.5.0/image.yaml
@@ -28,6 +28,7 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - amq-streams-1-for-rhel-7-server-rpms
   install:
     - java-1.8.0-openjdk-headless
     - gettext
@@ -37,6 +38,7 @@ packages:
     - stunnel
     - net-tools
     - bind-utils
+    - tini
 
 run:
   user: 1001

--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -27,15 +27,6 @@ mv ${TMP}/* ${CRUISE_CONTROL_HOME}/
 # extract all the Kafka related scripts
 unzip ${SOURCES_DIR}/strimzi-kafka-scripts.zip -d ${SCRIPTS_DIR}
 
-# patch to remove "tini"
-FILES=$(find ${SCRIPTS_DIR} -type f -name "*_run.sh")
-for f in $FILES
-do
-  sed -i 's/\/usr\/bin\/tini -w -e 143 -- sh -c "${KAFKA_HOME}\/bin\/connect-distributed.sh \/tmp\/strimzi-connect.properties"/${KAFKA_HOME}\/bin\/connect-distributed.sh \/tmp\/strimzi-connect.properties/' $f
-  sed -i 's/\/usr\/bin\/tini -w -e 143 -- sh -c "${KAFKA_HOME}\/bin\/kafka-server-start.sh \/tmp\/strimzi.properties"/${KAFKA_HOME}\/bin\/kafka-server-start.sh \/tmp\/strimzi.properties/' $f
-  sed -i 's/\/usr\/bin\/tini -w -e 143 -- sh -c "${KAFKA_HOME}\/bin\/zookeeper-server-start.sh \/tmp\/zookeeper.properties"/${KAFKA_HOME}\/bin\/zookeeper-server-start.sh \/tmp\/zookeeper.properties/' $f
-done
-
 # NOTE: kafka folder alredy contains the s2i (so no need for a specific cp command)
 cp -r ${SCRIPTS_DIR}/kafka/* ${KAFKA_HOME}/
 chmod -R 755 ${KAFKA_HOME}

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -29,11 +29,13 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - amq-streams-1-for-rhel-7-server-rpms
   install:
     - java-1.8.0-openjdk-headless
     - openssl
     - nmap-ncat
     - hostname
+    - tini
 
 run:
   user: 1001

--- a/operator/modules/operator/install.sh
+++ b/operator/modules/operator/install.sh
@@ -28,13 +28,6 @@ done
 # extract all the operator related scripts
 unzip ${SOURCES_DIR}/strimzi-operator-scripts.zip -d ${SCRIPTS_DIR}
 
-# patch to remove "tini"
-FILES=$(find ${SCRIPTS_DIR} -type f -name "*.sh")
-for f in $FILES
-do
-  sed -i 's/\/usr\/bin\/tini -w -e 143 -- //' $f
-done
-
 # copy module related scripts
 cp -r ${SCRIPTS_DIR}/* ${STRIMZI_HOME}/bin
 


### PR DESCRIPTION
Signed-off-by: Kyle Liberti <kliberti@redhat.com>

The productized `tini` package version 0.18.0 has finally been released into the `amq-streams-1-for-rhel-7-server-rpms` repo so we can now start using it with our images!

Tested the changes on OpenShift and everything works great!