### PR TITLE
Update content_sets.yml with rpm repos used by UBI base image

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -29,6 +29,8 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-atomic-host-rpms
+      - rhel-7-desktop-extras-rpms
   install:
     - java-1.8.0-openjdk-headless
     - openssl

--- a/kafka/kafka-2.4.0/image.yaml
+++ b/kafka/kafka-2.4.0/image.yaml
@@ -28,6 +28,8 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-atomic-host-rpms
+      - rhel-7-desktop-extras-rpms
   install:
     - java-1.8.0-openjdk-headless
     - gettext

--- a/kafka/kafka-2.5.0/image.yaml
+++ b/kafka/kafka-2.5.0/image.yaml
@@ -28,6 +28,8 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-atomic-host-rpms
+      - rhel-7-desktop-extras-rpms
   install:
     - java-1.8.0-openjdk-headless
     - gettext

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -29,6 +29,8 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-atomic-host-rpms
+      - rhel-7-desktop-extras-rpms
   install:
     - java-1.8.0-openjdk-headless
     - openssl


### PR DESCRIPTION
These repos are used by the UBI base image and new CVP policy requires us to list them in our content_sets.yml

Signed-off-by: Kyle Liberti <kliberti@redhat.com>