### PR TITLE
Fix typo Kafka Cannect to Kafka Connect

### DIFF
--- a/common/modules/olm/manifests/1.5.0/amq-streams.v1.5.0.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.5.0/amq-streams.v1.5.0.clusterserviceversion.yaml
@@ -1190,7 +1190,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: The Kafka cluster where the underlying Kafka Cannect connects
+      - description: The Kafka cluster where the underlying Kafka Connect connects
         displayName: Connect cluster
         path: connectCluster
         x-descriptors:

--- a/common/modules/olm/manifests/1.5.1/amq-streams.v1.5.1.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.5.1/amq-streams.v1.5.1.clusterserviceversion.yaml
@@ -1201,7 +1201,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: The Kafka cluster where the underlying Kafka Cannect connects
+      - description: The Kafka cluster where the underlying Kafka Connect connects
         displayName: Connect cluster
         path: connectCluster
         x-descriptors:

--- a/common/modules/olm/manifests/1.5.2/amq-streams.v1.5.2.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.5.2/amq-streams.v1.5.2.clusterserviceversion.yaml
@@ -1201,7 +1201,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: The Kafka cluster where the underlying Kafka Cannect connects
+      - description: The Kafka cluster where the underlying Kafka Connect connects
         displayName: Connect cluster
         path: connectCluster
         x-descriptors:

--- a/common/modules/olm/manifests/1.5.3/amq-streams.v1.5.3.clusterserviceversion.yaml
+++ b/common/modules/olm/manifests/1.5.3/amq-streams.v1.5.3.clusterserviceversion.yaml
@@ -1201,7 +1201,7 @@ spec:
         path: version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: The Kafka cluster where the underlying Kafka Cannect connects
+      - description: The Kafka cluster where the underlying Kafka Connect connects
         displayName: Connect cluster
         path: connectCluster
         x-descriptors:


### PR DESCRIPTION
This resolves issue: https://github.com/jboss-container-images/amqstreams-1-openshift-image/issues/227

I can cherry-pick these fixes to the amqstreams15-dev branch afterwards in case there is another CVE crops up for 1.5.0