### PR TITLE
Remove amq-streams.package.yaml file from old package manifest format

### DIFF
--- a/operator-metadata/manifests/amq-streams.package.yaml
+++ b/operator-metadata/manifests/amq-streams.package.yaml
@@ -1,9 +1,0 @@
-packageName: amq-streams
-channels:
-- name: stable
-  currentCSV: amqstreams.v1.5.3
-- name: amq-streams-1.x
-  currentCSV: amqstreams.v1.5.3
-- name: amq-streams-1.5.x
-  currentCSV: amqstreams.v1.5.3
-defaultChannel: stable


### PR DESCRIPTION
I accidentally included this file from the old format when migrating the files for the bundle format. This PR removes that unnecessary file. I'll cherry-pick the change to 16-dev branch