### PR TITLE
Upgrade to Java 11 and add debugging tools

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -31,15 +31,18 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-7-server-optional-rpms
       - amq-streams-1-for-rhel-7-server-rpms
       - rhel-atomic-host-rpms
       - rhel-7-desktop-extras-rpms
   install:
-    - java-1.8.0-openjdk-headless
+    - java-11-openjdk-devel
     - openssl
     - nmap-ncat
     - hostname
     - tini
+    - net-tools
+    - lsof
 
 run:
   user: 1001

--- a/kafka/kafka-2.4.0/image.yaml
+++ b/kafka/kafka-2.4.0/image.yaml
@@ -30,11 +30,12 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - java-11-openjdk-devel
       - amq-streams-1-for-rhel-7-server-rpms
       - rhel-atomic-host-rpms
       - rhel-7-desktop-extras-rpms
   install:
-    - java-1.8.0-openjdk-headless
+    - java-11-openjdk-devel
     - gettext
     - nmap-ncat
     - openssl
@@ -43,6 +44,7 @@ packages:
     - net-tools
     - bind-utils
     - tini
+    - lsof
  
 run:
   user: 1001

--- a/kafka/kafka-2.5.0/image.yaml
+++ b/kafka/kafka-2.5.0/image.yaml
@@ -30,11 +30,12 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-7-server-optional-rpms
       - amq-streams-1-for-rhel-7-server-rpms
       - rhel-atomic-host-rpms
       - rhel-7-desktop-extras-rpms
   install:
-    - java-1.8.0-openjdk-headless
+    - java-11-openjdk-devel
     - gettext
     - nmap-ncat
     - openssl
@@ -43,7 +44,7 @@ packages:
     - net-tools
     - bind-utils
     - tini
-
+    - lsof
 run:
   user: 1001
   workdir: $KAFKA_HOME

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -31,15 +31,18 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-7-server-optional-rpms
       - amq-streams-1-for-rhel-7-server-rpms
       - rhel-atomic-host-rpms
       - rhel-7-desktop-extras-rpms
   install:
-    - java-1.8.0-openjdk-headless
+    - java-11-openjdk-devel
     - openssl
     - nmap-ncat
     - hostname
     - tini
+    - net-tools
+    - lsof
 
 run:
   user: 1001


### PR DESCRIPTION
Resolves #216 #217 and  #235

- Updates images to use Java 11
- Uses Java 11 package containing requested JVM debugging tools
- Installs other requested packages like `net-tools` and `lsof` for debugging

Note Kafka image descriptors already have `net-tools` RPM listed for install