### PR TITLE
Enable all TLS versions in Kafka and EO sidecars

### DIFF
--- a/kafka/modules/kafka/base/stunnel-scripts/entity_operator_stunnel_config_generator.sh
+++ b/kafka/modules/kafka/base/stunnel-scripts/entity_operator_stunnel_config_generator.sh
@@ -9,6 +9,7 @@ cat /etc/tls-sidecar/cluster-ca-certs/*.crt > "$CA_CERTS"
 echo "pid = /usr/local/var/run/stunnel.pid"
 echo "foreground = yes"
 echo "debug = $TLS_SIDECAR_LOG_LEVEL"
+echo "sslVersion = all"
 
 cat <<-EOF
 [zookeeper-2181]

--- a/kafka/modules/kafka/base/stunnel-scripts/kafka_stunnel_config_generator.sh
+++ b/kafka/modules/kafka/base/stunnel-scripts/kafka_stunnel_config_generator.sh
@@ -11,6 +11,7 @@ CURRENT=${BASE_HOSTNAME}-${KAFKA_BROKER_ID}
 echo "pid = /usr/local/var/run/stunnel.pid"
 echo "foreground = yes"
 echo "debug = $TLS_SIDECAR_LOG_LEVEL"
+echo "sslVersion = all"
 
 cat <<-EOF
 [zookeeper-2181]


### PR DESCRIPTION
Enable all TLS protocol versions in the Kafka and EO sidecars to make them work smoothly after the 1.5 upgrade.