### PR TITLE
Update MD5s for AMQ Streams 1.6.0 CR1

### DIFF
--- a/bridge/modules/bridge/module.yaml
+++ b/bridge/modules/bridge/module.yaml
@@ -10,9 +10,9 @@ envs:
     value: "amqstreams-bridge-container"
 
 artifacts:
-  - md5: 1ecdc23162ddc88c3433c57edd8f00ce
+  - md5: 6f9cacd0e38ec1b74b08098471297605
     name: kafka-bridge.zip
-  - md5: e98a050d0eda037e95947ea0c5571ce9
+  - md5: 7d182ed200daa7bdc3afe33ef161a1b6
     name: kafka-bridge-licenses.tar.gz
 
 packages:

--- a/kafka/kafka-2.6.0/image.yaml
+++ b/kafka/kafka-2.6.0/image.yaml
@@ -30,7 +30,7 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
-      - java-11-openjdk-devel
+      - rhel-7-server-optional-rpms
       - amq-streams-1-for-rhel-7-server-rpms
       - rhel-atomic-host-rpms
       - rhel-7-desktop-extras-rpms

--- a/kafka/modules/kafka/2.5.0/module.yaml
+++ b/kafka/modules/kafka/2.5.0/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams-kafka-25-container"
 
 artifacts:
-  - md5: e8afffe3b1013869bf065ae070abed26
+  - md5: ad913ac937ee29e1df75e832befd9c8a
     name: streams-ocp-25.zip
 
 modules:

--- a/kafka/modules/kafka/2.5.0/module.yaml
+++ b/kafka/modules/kafka/2.5.0/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams-kafka-25-container"
 
 artifacts:
-  - md5: 6c56f9d50050ecf03ce0f1bf6c646971
+  - md5: e8afffe3b1013869bf065ae070abed26
     name: streams-ocp-25.zip
 
 modules:

--- a/kafka/modules/kafka/2.6.0/install.sh
+++ b/kafka/modules/kafka/2.6.0/install.sh
@@ -14,7 +14,7 @@ mv ${TMP}/* ${KAFKA_HOME}/
 cp -r ${KAFKA_HOME}/bin/kafka_exporter ${KAFKA_EXPORTER_HOME}/
 
 mkdir -p ${PRODUCT_LICENSE_DIR}/kafka
-cp ${KAFKA_HOME}/docs/licen*/* ${PRODUCT_LICENSE_DIR}/kafka
+cp -r ${KAFKA_HOME}/licen*/* ${PRODUCT_LICENSE_DIR}/kafka
 
 mkdir -p ${PRODUCT_LICENSE_DIR}/cruise-control
 cp -r ${CRUISE_CONTROL_HOME}/docs/licen*/* ${PRODUCT_LICENSE_DIR}/cruise-control

--- a/kafka/modules/kafka/2.6.0/module.yaml
+++ b/kafka/modules/kafka/2.6.0/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams-kafka-26-container"
 
 artifacts:
-  - md5: abddf80294f687718dc53b7cc4ca00f7
+  - md5: b0b3c6c10dddf594b174adcfe9d7d278
     name: streams-ocp-26.zip
 
 modules:

--- a/kafka/modules/kafka/2.6.0/module.yaml
+++ b/kafka/modules/kafka/2.6.0/module.yaml
@@ -8,7 +8,7 @@ envs:
     value: "amqstreams-kafka-26-container"
 
 artifacts:
-  - md5: b0b3c6c10dddf594b174adcfe9d7d278
+  - md5: e3bf30dc8663787f123c4abba89de2ed
     name: streams-ocp-26.zip
 
 modules:

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -18,7 +18,7 @@ envs:
 artifacts:
   - md5: 7370ad8b47494abdcb955ff87b7502a0
     name: strimzi-kafka-scripts.zip
-  - md5: 9503a31dc27433926d29b4d572a51c86
+  - md5: e5153275d8ec6cc6a610eb4a1d67bec8
     name: cruise-control-ocp.zip
 
 packages:

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -16,9 +16,9 @@ envs:
     value: "/opt/cruise-control"
 
 artifacts:
-  - md5: 6d738f7eee086904d15d6c0e77e00bb3
+  - md5: 7370ad8b47494abdcb955ff87b7502a0
     name: strimzi-kafka-scripts.zip
-  - md5: b1e7f7afc40a8acfb1429bbd779ce96b
+  - md5: 9503a31dc27433926d29b4d572a51c86
     name: cruise-control-ocp.zip
 
 packages:

--- a/operator/modules/operator/module.yaml
+++ b/operator/modules/operator/module.yaml
@@ -10,17 +10,17 @@ envs:
     value: "amqstreams-operator-container"
 
 artifacts:
-  - md5: de23b48954d17282a4b82d7c8d5af4d6
+  - md5: b0a4a1a034022cd8b456eeaae43db337 
     name: cluster-operator-dist.zip
-  - md5: 4fc3520c8c8c398e24c5b594a19f1df0
+  - md5: 24ea4deb1057ead092d9670c7f72aaf1
     name: topic-operator-dist.zip
-  - md5: d864c99e40b582ade17d1a3bb229dd65
+  - md5: 092614b87c7ce328618baef8a55a2117
     name: user-operator-dist.zip
-  - md5: ddf3c193a2240874e25e223aa1cd4836
+  - md5: c391041b97b4d4958ffe056b1766837a
     name: kafka-init-dist.zip
-  - md5: 24b7f1f8b51ebd40f3f180fe39f3badd
+  - md5: c21bb340edf30366542e3f55449e023f
     name: strimzi-licenses.tar.gz
-  - md5: a68decb90a4ab9b4298b878269a8059d
+  - md5: 178ec76ba0b8f0c439c21b15fd639e04
     name: strimzi-operator-scripts.zip
 
 packages:


### PR DESCRIPTION
The Cluster Operator jar needs to be rebuilt with an updated ` kafka-versions.yaml `file so it does not include Kafka 2.5.1. Once it is rebuilt I will update this PR with the appropriate MD5s and take it out of draft mode

CC @ppatierno (Hold off on the review until we update the Cluster Operator fixes!)
