### PR TITLE
Add the inter.broker.protocol.version to our examples

### DIFF
--- a/examples/cruise-control/kafka-cruise-control.yaml
+++ b/examples/cruise-control/kafka-cruise-control.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-ephemeral-single.yaml
+++ b/examples/kafka/kafka-ephemeral-single.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-ephemeral.yaml
+++ b/examples/kafka/kafka-ephemeral.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/kafka/kafka-jbod.yaml
+++ b/examples/kafka/kafka-jbod.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent-single.yaml
+++ b/examples/kafka/kafka-persistent-single.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/kafka/kafka-persistent.yaml
+++ b/examples/kafka/kafka-persistent.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/metrics/jmxtrans/jmxtrans.yaml
+++ b/examples/metrics/jmxtrans/jmxtrans.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
     jmxOptions:

--- a/examples/metrics/kafka-cruise-control-metrics.yaml
+++ b/examples/metrics/kafka-cruise-control-metrics.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: ephemeral
   zookeeper:

--- a/examples/metrics/kafka-metrics.yaml
+++ b/examples/metrics/kafka-metrics.yaml
@@ -26,6 +26,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/mirror-maker/kafka-source.yaml
+++ b/examples/mirror-maker/kafka-source.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/mirror-maker/kafka-target.yaml
+++ b/examples/mirror-maker/kafka-target.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/security/scram-sha-512-auth/kafka.yaml
+++ b/examples/security/scram-sha-512-auth/kafka.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/security/tls-auth/kafka.yaml
+++ b/examples/security/tls-auth/kafka.yaml
@@ -20,6 +20,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.6"
+      inter.broker.protocol.version: "2.6"
     storage:
       type: jbod
       volumes:

--- a/examples/templates/cluster-operator/ephemeral-template.yaml
+++ b/examples/templates/cluster-operator/ephemeral-template.yaml
@@ -94,6 +94,7 @@ objects:
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
         log.message.format.version: ${KAFKA_VERSION}
+        inter.broker.protocol.version: ${KAFKA_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:

--- a/examples/templates/cluster-operator/persistent-template.yaml
+++ b/examples/templates/cluster-operator/persistent-template.yaml
@@ -105,6 +105,7 @@ objects:
         offsets.topic.replication.factor: ${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}
         transaction.state.log.replication.factor: ${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR}
         log.message.format.version: ${KAFKA_VERSION}
+        inter.broker.protocol.version: ${KAFKA_VERSION}
     zookeeper:
       replicas: ${{ZOOKEEPER_NODE_COUNT}}
       livenessProbe:

--- a/operator-metadata/manifests/amq-streams.v1.6.0.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/amq-streams.v1.6.0.clusterserviceversion.yaml
@@ -67,7 +67,8 @@ metadata:
                   "offsets.topic.replication.factor":3,
                   "transaction.state.log.replication.factor":3,
                   "transaction.state.log.min.isr":2,
-                  "log.message.format.version":"2.6"
+                  "log.message.format.version":"2.6",
+                  "inter.broker.protocol.version":"2.6"
                 },
                 "storage":{
                   "type":"ephemeral"


### PR DESCRIPTION
Thsi Pr adds the `inter.broker.protocol.version` to our examples to have it fixed there.