### PR TITLE
Update content_sets to meet new CVP requirements

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -30,11 +30,12 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-      - rhel-7-server-rpms
-      - rhel-7-server-optional-rpms
+      # Required for tini 0.18
       - amq-streams-1-for-rhel-7-server-rpms
+      # Required for base image
+      - rhel-7-server-rpms
+      - rhel-7-server-extras-rpms
       - rhel-atomic-host-rpms
-      - rhel-7-desktop-extras-rpms
   install:
     - java-11-openjdk-devel
     - openssl

--- a/kafka/kafka-2.5.0/image.yaml
+++ b/kafka/kafka-2.5.0/image.yaml
@@ -29,11 +29,12 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-      - rhel-7-server-rpms
-      - rhel-7-server-optional-rpms
+      # Required for tini 0.18
       - amq-streams-1-for-rhel-7-server-rpms
+      # Required for base image
+      - rhel-7-server-rpms
+      - rhel-7-server-extras-rpms
       - rhel-atomic-host-rpms
-      - rhel-7-desktop-extras-rpms
   install:
     - java-11-openjdk-devel
     - gettext

--- a/kafka/kafka-2.6.0/image.yaml
+++ b/kafka/kafka-2.6.0/image.yaml
@@ -29,11 +29,12 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-      - rhel-7-server-rpms
-      - rhel-7-server-optional-rpms
+      # Required for tini 0.18
       - amq-streams-1-for-rhel-7-server-rpms
+      # Required for base image
+      - rhel-7-server-rpms
+      - rhel-7-server-extras-rpms
       - rhel-atomic-host-rpms
-      - rhel-7-desktop-extras-rpms
   install:
     - java-11-openjdk-devel
     - gettext

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -30,11 +30,12 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-      - rhel-7-server-rpms
-      - rhel-7-server-optional-rpms
+      # Required for tini 0.18
       - amq-streams-1-for-rhel-7-server-rpms
+      # Required for base image
+      - rhel-7-server-rpms 
+      - rhel-7-server-extras-rpms
       - rhel-atomic-host-rpms
-      - rhel-7-desktop-extras-rpms
   install:
     - java-11-openjdk-devel
     - openssl


### PR DESCRIPTION
TL;DR CVP is adding a new requirements which require an update to our content_sets:

1) An RPM we install cannot be provided from more than one repo in our content_sets
2) We must list exact content_sets of our base image in our content_sets

We violated (1) since the `java-11-openjdk-devel` package was moved to the `rhel-7-server-rpms` repo. The `java-11-openjdk-devel` packaged is now provided by both the `rhel-7-server-rpms` and `rhel-7-server-optional-rpms` repos. To remedy this, we remove the `rhel-7-server-optional-rpms` repo which was added explicitly for the `java-11-openjdk-devel` package.

We violated (2) since we used `rhel-7-desktop-extras-rpms` instead of `rhel-7-server-extras-rpms`. Both repos provide the needed RPMs, but we must match the repos used by the base image.

Added some comments so we remember why we use certain repos. We have one repo that provides our custom version of tini and all the other repos are inherited by our base image and provide all of the other RPMs that we install.