### PR TITLE
Revert backport flag to true, which is necessary for OCP 4.5

### DIFF
--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -31,7 +31,7 @@ labels:
   - name: "com.redhat.openshift.versions"
     value: "v4.5"
   - name: "com.redhat.delivery.backport"
-    value: "false"
+    value: "true"
   - name: "maintainer"
     value: "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
 


### PR DESCRIPTION
The backport label `com.redhat.delivery.backport` causes the bundle to be backported to all OCP version <= 4.6.

Although we don't want this bundle backported to OCP versions < 4.5 we must do so if we want to support OLM install on OCP 4.5.

Reverting change back to set `com.redhat.delivery.backport` to `true`