### PR TITLE
Drop support for legacy app registry of OCP v4.5

### DIFF
--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -29,9 +29,7 @@ labels:
   - name: "com.redhat.delivery.operator.bundle"
     value: "true"
   - name: "com.redhat.openshift.versions"
-    value: "v4.5"
-  - name: "com.redhat.delivery.backport"
-    value: "true"
+    value: "v4.6"
   - name: "maintainer"
     value: "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
 


### PR DESCRIPTION
Resolves https://github.com/jboss-container-images/amqstreams-1-openshift-image/issues/263