### PR TITLE
Update MD5s for AMQ Streams 1.6.4 CR1

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: amq7/amq-streams-bridge-rhel7
 description: "AMQ Streams image for running the Apache Kafka bridge"
-version: "1.6.2"
+version: "1.6.4"
 from: registry.redhat.io/ubi7/ubi-minimal
 
 labels:

--- a/bridge/modules/bridge/module.yaml
+++ b/bridge/modules/bridge/module.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: bridge
-version: 1.6.2
+version: 1.6.4
 
 envs:
   - name: "STRIMZI_HOME"

--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -23,7 +23,7 @@ spec:
             name: strimzi-cluster-operator
       containers:
         - name: strimzi-cluster-operator
-          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
           ports:
             - containerPort: 8080
               name: http
@@ -42,41 +42,41 @@ spec:
             - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "300000"
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_KAFKA_IMAGES
               value: |
-                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.2
-                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.4
+                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
-                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.2
-                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.4
+                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
               value: |
-                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.2
-                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.4
+                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
-                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.2
-                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.4
+                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
-                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.2
-                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.2
+                2.5.0=registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.6.4
+                2.6.0=registry.redhat.io/amq7/amq-streams-kafka-26-rhel7:1.6.4
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-              value: registry.redhat.io/amq7/amq-streams-bridge-rhel7:1.6.2
+              value: registry.redhat.io/amq7/amq-streams-bridge-rhel7:1.6.4
           livenessProbe:
             httpGet:
               path: /healthy

--- a/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
+++ b/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-topic-operator
       containers:
         - name: strimzi-topic-operator
-          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
           args:
           - /opt/strimzi/bin/topic_operator_run.sh
           env:

--- a/install/user-operator/05-Deployment-strimzi-user-operator.yaml
+++ b/install/user-operator/05-Deployment-strimzi-user-operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: strimzi-user-operator
       containers:
         - name: strimzi-user-operator
-          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.2
+          image: registry.redhat.io/amq7/amq-streams-rhel7-operator:1.6.4
           args:
           - /opt/strimzi/bin/user_operator_run.sh
           env:

--- a/kafka/kafka-2.5.0/image.yaml
+++ b/kafka/kafka-2.5.0/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: amq7/amq-streams-kafka-25-rhel7
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect, Mirror Maker and Cruise Control"
-version: "1.6.2"
+version: "1.6.4"
 from: registry.redhat.io/ubi7/ubi-minimal
 
 labels:

--- a/kafka/kafka-2.6.0/image.yaml
+++ b/kafka/kafka-2.6.0/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: amq7/amq-streams-kafka-26-rhel7
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect, Mirror Maker and Cruise Control"
-version: "1.6.2"
+version: "1.6.4"
 from: registry.redhat.io/ubi7/ubi-minimal
 
 labels:

--- a/kafka/modules/kafka/2.5.0/module.yaml
+++ b/kafka/modules/kafka/2.5.0/module.yaml
@@ -8,13 +8,13 @@ envs:
     value: "amqstreams-kafka-25-container"
 
 artifacts:
-  - md5: f0e09ac0cedebdbf13e5ffaf5c235278
+  - md5: 1bc26a4790e1a2f520cba04cdfea678d
     name: streams-ocp-25.zip
 
 modules:
   install:
   - name: kafka.base
-    version: 1.6.2
+    version: 1.6.4
 
 execute:
   - script: install.sh

--- a/kafka/modules/kafka/2.6.0/module.yaml
+++ b/kafka/modules/kafka/2.6.0/module.yaml
@@ -8,13 +8,13 @@ envs:
     value: "amqstreams-kafka-26-container"
 
 artifacts:
-  - md5: d5bbbac769d575d3df800b0b913a01e2
+  - md5: 85cee2b31ac41675e954bb12f240377c
     name: streams-ocp-26.zip
 
 modules:
   install:
   - name: kafka.base
-    version: 1.6.2
+    version: 1.6.4
 
 execute:
   - script: install.sh

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: kafka.base
-version: 1.6.2
+version: 1.6.4
 
 envs:
   - name: "KAFKA_HOME"
@@ -18,7 +18,7 @@ envs:
 artifacts:
   - md5: c5c48c3879094a42c271fbf561193b6e
     name: strimzi-kafka-scripts.zip
-  - md5: 58a16a93070fb1fd91f2946a5d8f6cac
+  - md5: 946d7ae019f52e33fff6d8e6c31284ac
     name: cruise-control-ocp.zip
 
 packages:

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: amq7/amq-streams-rhel7-operator
 description: "AMQ Streams image for the Cluster, Topic, User Operators, and Kafka init"
-version: "1.6.2"
+version: "1.6.4"
 from: registry.redhat.io/ubi7/ubi-minimal
 
 labels:

--- a/operator/modules/operator/module.yaml
+++ b/operator/modules/operator/module.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: operator
-version: 1.6.2
+version: 1.6.4
 
 envs:
   - name: "STRIMZI_HOME"


### PR DESCRIPTION
To avoid customer confusion we are:
- Jumping the image version from `1.6.2` -> `1.6.4` to align with the decoupled bundle version.
- Bumping the versions for all components even though only the Kafka images changed to keep the AMQ Streams components coupled.