### PR TITLE
Set olm.maxOpenShiftVersion

### DIFF
--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -355,6 +355,8 @@ metadata:
       ["Disconnected", "Proxy"]
     operators.openshift.io/valid-subscription: |-
       ["Red Hat Integration", "Red Hat AMQ"]  
+    olm.properties: |-
+      [{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]
   name: amqstreams.v1.8.0
   namespace: placeholder
 spec:

--- a/operator-metadata/metadata/annotations.yaml
+++ b/operator-metadata/metadata/annotations.yaml
@@ -1,4 +1,5 @@
 annotations:
+  com.redhat.openshift.versions: v4.6
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.bundle.channels.v1: stable,amq-streams-1.x,amq-streams-1.8.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/


### PR DESCRIPTION
These annotations prevent indexes being generated and bundles being installed on unsupported OCP versions.

Note the annotation in the `metadata/annotations.yaml` matches the label in our image.yaml file, this is a new requirement!

Resolves https://github.com/jboss-container-images/amqstreams-1-openshift-image/issues/283