### PR TITLE
Remove redundant content_sets

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -35,7 +35,6 @@ packages:
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
-      - rhel-atomic-host-rpms
   install:
     - java-11-openjdk-devel
     - openssl

--- a/kafka/kafka-2.7.0/image.yaml
+++ b/kafka/kafka-2.7.0/image.yaml
@@ -34,7 +34,6 @@ packages:
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
-      - rhel-atomic-host-rpms
   install:
     - java-11-openjdk-devel
     - gettext

--- a/kafka/kafka-2.8.0/image.yaml
+++ b/kafka/kafka-2.8.0/image.yaml
@@ -34,7 +34,6 @@ packages:
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
-      - rhel-atomic-host-rpms
   install:
     - java-11-openjdk-devel
     - gettext

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -35,7 +35,6 @@ packages:
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
-      - rhel-atomic-host-rpms
   install:
     - java-11-openjdk-devel
     - openssl


### PR DESCRIPTION
All of the RPMs needed for our images are now shipped to the following content_sets:
      
- amq-streams-1-for-rhel-8-rpms
- rhel-8-for-x86_64-baseos-rpms
- rhel-8-for-x86_64-appstream-rpms

making the `rhel-atomic-host-rpms` content_set redundant. In the near future, the Red Hat build pipeline will block container builds which have redundant content_sets, therefore we should remove `rhel-atomic-host-rpms` now! 