### PR TITLE
Fix kafka_exporter scripts to handle RPM install + cekit content_sets issue

### DIFF
--- a/kafka/kafka-2.8.0/image.yaml
+++ b/kafka/kafka-2.8.0/image.yaml
@@ -31,12 +31,16 @@ packages:
     x86_64:
       # Required for tini
       - amq-streams-1-for-rhel-8-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-rpms
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
     ppc64le:
       # Required for tini
       - amq-streams-1-for-rhel-8-ppc64le-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
       - rhel-8-for-ppc64le-baseos-rpms
       - rhel-8-for-ppc64le-appstream-rpms
@@ -51,7 +55,6 @@ packages:
     - bind-utils
     - tini
     - lsof
-    - kafka_exporter
  
 run:
   user: 1001

--- a/kafka/kafka-3.0.0/image.yaml
+++ b/kafka/kafka-3.0.0/image.yaml
@@ -31,12 +31,16 @@ packages:
     x86_64:
       # Required for tini
       - amq-streams-1-for-rhel-8-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-rpms
       # Required for base image
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
     ppc64le:
       # Required for tini
       - amq-streams-1-for-rhel-8-ppc64le-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
       - rhel-8-for-ppc64le-baseos-rpms
       - rhel-8-for-ppc64le-appstream-rpms
@@ -51,7 +55,6 @@ packages:
     - bind-utils
     - tini
     - lsof
-    - kafka_exporter
  
 run:
   user: 1001

--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -13,6 +13,7 @@ useradd -r -m -u 1001 -g 0 strimzi
 mkdir $KAFKA_HOME
 mkdir $STUNNEL_HOME
 mkdir $S2I_HOME
+mkdir $KAFKA_EXPORTER_HOME
 mkdir $CRUISE_CONTROL_HOME
 mkdir -p -m g+rw /usr/local/var/run/
 
@@ -32,6 +33,10 @@ chmod -R 755 ${KAFKA_HOME}
 
 cp -r ${SCRIPTS_DIR}/stunnel/* ${STUNNEL_HOME}/
 chmod -R 755 ${STUNNEL_HOME}
+
+mv /usr/bin/kafka_exporter ${KAFKA_EXPORTER_HOME}/
+cp -r ${SCRIPTS_DIR}/kafka-exporter/* ${KAFKA_EXPORTER_HOME}/
+chmod -R 755 ${KAFKA_EXPORTER_HOME}
 
 cp -r ${SCRIPTS_DIR}/cruise-control/* ${CRUISE_CONTROL_HOME}/
 chmod -R 755 ${CRUISE_CONTROL_HOME}

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -11,7 +11,7 @@ envs:
   - name: "S2I_HOME"
     value: "/opt/kafka/s2i"
   - name: "KAFKA_EXPORTER_HOME"
-    value: "/usr/bin"
+    value: "/opt/kafka-exporter"
   - name: "CRUISE_CONTROL_HOME"
     value: "/opt/cruise-control"
 
@@ -25,10 +25,12 @@ packages:
   manager: microdnf
   content_sets:
     x86_64:
-      - amq-streams-1-for-rhel-8-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-rpms
       - rhel-8-for-x86_64-baseos-rpms
     ppc64le:
-      - amq-streams-1-for-rhel-8-ppc64le-rpms
+      # Required for kafka_exporter
+      - amq-streams-2-for-rhel-8-ppc64le-rpms
       - rhel-8-for-ppc64le-baseos-rpms
   install:
     - unzip


### PR DESCRIPTION
A couple of issues resolved here:

1. A bug in Cekit [1] is preventing the `amq-streams-2-for-rhel-8-rpms` listed in our kafka base module.yaml from being searched   [1] so we must list it in both our `kafka-2.8.0` and `kafka-3.0.0` image.yamls in order for the module to install the `kafka_exporter` RPM.
2. Currently the `tini` and `kafka_exporter` RPMs are located in the `amq-streams-1-for-rhel-8-rpms` and `amq-streams-2-for-rhel-8-rpms` respectively, so both must be listed. Working with EXD to consolidate all RPMs to `amq-streams-2-for-rhel-8-rpms` but may take some time before we can rely on `amq-streams-2-for-rhel-8-rpms` alone.
4. Reverting some accidental kafka_exporter script/modules changes  + adding a line to handle the placement/install of the kafka_exporter binary now that we are installing it via RPM.

[1] https://github.com/cekit/cekit/issues/757