### PR TITLE
Fix incorrect space in the metering labels breaking the MM2 deployment

### DIFF
--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -151,7 +151,7 @@ spec:
                 com.company=Red_Hat
                 rht.prod_name=Red_Hat_Integration
                 rht.prod_ver=2021.Q4
-                rht.comp= AMQ_Streams
+                rht.comp=AMQ_Streams
                 rht.comp_ver=2.0
                 rht.subcomp=kafka-mirror-maker2
                 rht.comp_t=application


### PR DESCRIPTION
The metering labels for the Mirror Maker 2 deployment seem to be wrong with an space after `=`. This is causing followjng error when running the operator:

```
2021-11-15 21:22:49 ERROR AbstractOperator:382 - Reconciliation #35(timer) KafkaMirrorMaker2(log-setting-cluster-test/my-cluster-1432217751-mirror-maker-2): Reconciliation failed
java.lang.NoClassDefFoundError: Could not initialize class io.strimzi.operator.cluster.model.KafkaMirrorMaker2Cluster
	at io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator.createOrUpdate(KafkaMirrorMaker2AssemblyOperator.java:138) ~[io.strimzi.cluster-operator-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.cluster.operator.assembly.KafkaMirrorMaker2AssemblyOperator.createOrUpdate(KafkaMirrorMaker2AssemblyOperator.java:83) ~[io.strimzi.cluster-operator-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.common.AbstractOperator.lambda$reconcile$7(AbstractOperator.java:221) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.common.AbstractOperator.lambda$withLock$15(AbstractOperator.java:367) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:196) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.PromiseImpl.addListener(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl.onComplete(FutureImpl.java:164) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.PromiseImpl.onComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.shareddata.impl.SharedDataImpl.getLockWithTimeout(SharedDataImpl.java:100) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.strimzi.operator.common.AbstractOperator.withLock(AbstractOperator.java:357) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.common.AbstractOperator.reconcile(AbstractOperator.java:163) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.common.Operator.reconcileThese(Operator.java:79) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.strimzi.operator.common.Operator.lambda$reconcileAll$0(Operator.java:63) ~[io.strimzi.operator-common-0.26.0.redhat-00001.jar:0.26.0.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.Mapping.onSuccess(Mapping.java:40) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.PromiseImpl.onSuccess(PromiseImpl.java:49) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:54) ~[io.vertx.vertx-core-4.1.5.redhat-00001.jar:4.1.5.redhat-00001]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [io.netty.netty-common-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) [io.netty.netty-common-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) [io.netty.netty-transport-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty.netty-common-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty.netty-common-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty.netty-common-4.1.68.Final-redhat-00001.jar:4.1.68.Final-redhat-00001]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

This seems to be only in the YAML files for ZIP install and not in the bundle.