### PR TITLE
Fix AMQ Streams 2.1.0 skipRange start interval

### DIFF
--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -381,7 +381,7 @@ metadata:
       ["Disconnected", "Proxy"]
     operators.openshift.io/valid-subscription: |-
       ["Red Hat Integration", "Red Hat AMQ"]
-    olm.skipRange: '>=2.0.1-0 <2.1.0-0'
+    olm.skipRange: '>=2.0.0-0 <2.1.0-0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported


### PR DESCRIPTION
I made a mistake when setting the start interval of the skipRange field. Users should be able to skip between micro versions of AMQ Streams and be able to jump from any version starting from `2.0.0-0` directly to `2.1.0-0`