### PR TITLE
Updated CRDs due to cherry-pick of ENTMQST-3826

### DIFF
--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -1623,7 +1623,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -2919,7 +2919,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -4158,7 +4158,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -5224,7 +5224,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6145,7 +6145,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6778,7 +6778,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -888,7 +888,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1625,7 +1625,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -1106,7 +1106,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -913,7 +913,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -1015,7 +1015,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1752,7 +1752,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/operator-metadata/manifests/kafkabridges.kafka.strimzi.io.crd.yaml
+++ b/operator-metadata/manifests/kafkabridges.kafka.strimzi.io.crd.yaml
@@ -913,7 +913,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/operator-metadata/manifests/kafkaconnects.kafka.strimzi.io.crd.yaml
+++ b/operator-metadata/manifests/kafkaconnects.kafka.strimzi.io.crd.yaml
@@ -888,7 +888,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1625,7 +1625,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/operator-metadata/manifests/kafkamirrormaker2s.kafka.strimzi.io.crd.yaml
+++ b/operator-metadata/manifests/kafkamirrormaker2s.kafka.strimzi.io.crd.yaml
@@ -1015,7 +1015,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services
@@ -1752,7 +1752,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/operator-metadata/manifests/kafkamirrormakers.kafka.strimzi.io.crd.yaml
+++ b/operator-metadata/manifests/kafkamirrormakers.kafka.strimzi.io.crd.yaml
@@ -1106,7 +1106,7 @@ spec:
                         pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                         description: Defines the total amount (for example `1Gi`)
                           of local storage required for temporary EmptyDir volume
-                          (`/tmp`). Default value is `1Mi`.
+                          (`/tmp`). Default value is `5Mi`.
                       enableServiceLinks:
                         type: boolean
                         description: Indicates whether information about services

--- a/operator-metadata/manifests/kafkas.kafka.strimzi.io.crd.yaml
+++ b/operator-metadata/manifests/kafkas.kafka.strimzi.io.crd.yaml
@@ -1623,7 +1623,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -2919,7 +2919,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -4158,7 +4158,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -5224,7 +5224,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6145,7 +6145,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services
@@ -6778,7 +6778,7 @@ spec:
                             pattern: ^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                             description: Defines the total amount (for example `1Gi`)
                               of local storage required for temporary EmptyDir volume
-                              (`/tmp`). Default value is `1Mi`.
+                              (`/tmp`). Default value is `5Mi`.
                           enableServiceLinks:
                             type: boolean
                             description: Indicates whether information about services


### PR DESCRIPTION
The https://github.com/strimzi/strimzi-kafka-operator/pull/6434 (related to ENTMQST-3826) was cherry picked for AMQ Streams 2.1 and it means some changes on the installed CRDs.