### PR TITLE
Add resource requests + limits for bundle

### DIFF
--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -1301,7 +1301,13 @@ spec:
                       port: http
                     initialDelaySeconds: 10
                     periodSeconds: 30
-                  resources: {}
+                  resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 384Mi
+                    requests:
+                      cpu: 200m
+                      memory: 384Mi
           strategy:
             type: Recreate
     strategy: deployment


### PR DESCRIPTION
Adding resource requests and limits to the bundle CSV after accidentally removing them back in Streams 1.7