### PR TITLE
Removed TLS sidecar image for Cruise Control

### DIFF
--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -1158,8 +1158,6 @@ spec:
                       value: registry.redhat.io/amq7/amq-streams-kafka-32-rhel8@sha256:030511435bfda574d28be829f4f4cfea201d30541c145dce1b8ff412b5c6fc1d
                     - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
                       value: registry.redhat.io/amq7/amq-streams-kafka-32-rhel8@sha256:030511435bfda574d28be829f4f4cfea201d30541c145dce1b8ff412b5c6fc1d
-                    - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-                      value: registry.redhat.io/amq7/amq-streams-kafka-32-rhel8@sha256:030511435bfda574d28be829f4f4cfea201d30541c145dce1b8ff412b5c6fc1d
                     - name: STRIMZI_KAFKA_IMAGES
                       value: |
                         3.1.0=registry.redhat.io/amq7/amq-streams-kafka-31-rhel8@sha256:030511435bfda574d28be829f4f4cfea201d30541c145dce1b8ff412b5c6fc1d


### PR DESCRIPTION
This PR removes the TLS sidecar image for Cruise Control env var because it's not used anymore in the new strimzi cluster operator.