### PR TITLE
Add workaround for libsolv issue

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -55,6 +55,8 @@ packages:
     - tini
     - net-tools
     - lsof
+    # Temporary hack to force correct nss package to be installed
+    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/drain-cleaner/image.yaml
+++ b/drain-cleaner/image.yaml
@@ -43,6 +43,8 @@ packages:
       - rhel-8-for-s390x-appstream-rpms  
   install:
     - java-11-openjdk-devel
+    # Temporary hack to force correct nss package to be installed
+    - crypto-policies-scripts
 
 ports:
     - value: 8080

--- a/kafka/kafka-3.2.3/image.yaml
+++ b/kafka/kafka-3.2.3/image.yaml
@@ -57,6 +57,8 @@ packages:
     - bind-utils
     - tini
     - lsof
+    # Temporary hack to force correct nss package to be installed
+    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/kafka/kafka-3.3.1/image.yaml
+++ b/kafka/kafka-3.3.1/image.yaml
@@ -57,6 +57,8 @@ packages:
     - bind-utils
     - tini
     - lsof
+    # Temporary hack to force correct nss package to be installed
+    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -56,6 +56,8 @@ packages:
     - net-tools
     - lsof
     - bind-utils
+    # Temporary hack to force correct nss package to be installed
+    - crypto-policies-scripts
 
 run:
   user: 1001


### PR DESCRIPTION
The `libsolv` package used by dnf for RPM dependency resolution was changed so that it doesn't always install the latest packages. This causes a stale `nss` package to be brought in as a dependency when we install java into our container images. Since the up-to-date `nss` package we need has the`crypto-policies-scripts` RPM package as a dependency ( and the stale `nss` package requires an older and different crypto-policy RPM package as a dependency), we can force the the installation of the up-to-date `nss` package by explicitly installing the `crypto-policies-scripts` RPM package.