### PR TITLE
Revert workaround for libsolv issue

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -55,8 +55,6 @@ packages:
     - tini
     - net-tools
     - lsof
-    # Temporary hack to force correct nss package to be installed
-    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/drain-cleaner/image.yaml
+++ b/drain-cleaner/image.yaml
@@ -43,8 +43,6 @@ packages:
       - rhel-8-for-s390x-appstream-rpms  
   install:
     - java-11-openjdk-devel
-    # Temporary hack to force correct nss package to be installed
-    - crypto-policies-scripts
 
 ports:
     - value: 8080

--- a/kafka/kafka-3.2.3/image.yaml
+++ b/kafka/kafka-3.2.3/image.yaml
@@ -57,8 +57,6 @@ packages:
     - bind-utils
     - tini
     - lsof
-    # Temporary hack to force correct nss package to be installed
-    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/kafka/kafka-3.3.1/image.yaml
+++ b/kafka/kafka-3.3.1/image.yaml
@@ -57,8 +57,6 @@ packages:
     - bind-utils
     - tini
     - lsof
-    # Temporary hack to force correct nss package to be installed
-    - crypto-policies-scripts
 
 run:
   user: 1001

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -56,8 +56,6 @@ packages:
     - net-tools
     - lsof
     - bind-utils
-    # Temporary hack to force correct nss package to be installed
-    - crypto-policies-scripts
 
 run:
   user: 1001


### PR DESCRIPTION
Revert workaround in YAML files which were created for libsolv issue [1] by removing  - crypto-policies-scripts


[1] https://github.com/jboss-container-images/amqstreams-1-openshift-image/pull/381