### PR TITLE
Reinstall timezone data for timezone log configuration

### DIFF
--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -40,3 +40,8 @@ chmod -R 755 ${KAFKA_EXPORTER_HOME}
 
 cp -r ${SCRIPTS_DIR}/cruise-control/* ${CRUISE_CONTROL_HOME}/
 chmod -R 755 ${CRUISE_CONTROL_HOME}
+
+# The ubi8-minimal image intentionally removes /usr/share/zoneinfo when installing the `tzdata` RPM package to save space.
+# However, since /usr/share/zoneinfo is needed by the kafka_exporter and cekit doesn't support RPM reinstall at this time,
+# we must reinstall the `tzdata` RPM package manually.
+microdnf reinstall -y tzdata


### PR DESCRIPTION
This PR resolves #388 by reinstalling the `tzdata` RPM package using cekit modules.

Note that we are only updating the Kafka operand images since they are the only images that contain non-java tools like the kafka_exporter that need the `/usr/share/timezone` data for timezone log configuration.

Anyways, built and tested changes and everything seems to work ok!