### PR TITLE
Update bundle replaced by Streams 2.4.0 CR1 bundle

### DIFF
--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -1375,7 +1375,7 @@ spec:
   maturity: stable
   provider:
     name: Red Hat
-  replaces: amqstreams.v2.3.0-2
+  replaces: amqstreams.v2.3.0-3
   selector:
     matchLabels:
       name: amq-streams-cluster-operator


### PR DESCRIPTION
A new AMQ Streams 2.3.0 bundle was respun last week, this PR is to keep it in the `stable` channel of the install graph when we release AMQ Streams 2.4.0