### PR TITLE
Backport fixes to Grafana dashboards

### DIFF
--- a/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-bridge.json
@@ -3020,6 +3020,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -3104,6 +3105,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -3188,6 +3190,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 8,

--- a/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
+++ b/examples/metrics/grafana-dashboards/strimzi-kafka-exporter.json
@@ -59,6 +59,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -140,6 +141,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -221,6 +223,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -302,6 +305,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -383,6 +387,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -464,6 +469,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Number of partitions which are at their minimum in sync replica count (| ISR | == | min.insync.replicas |)",
       "format": "none",
       "gauge": {
@@ -546,6 +552,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "description": "Number of partitions which are under their minimum in sync replica count (| ISR | < | min.insync.replicas |)",
       "format": "none",
       "gauge": {
@@ -628,6 +635,7 @@
         "#F2495C",
         "#d44a3a"
       ],
+      "datasource": "${DS_PROMETHEUS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -976,6 +984,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1049,6 +1058,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1122,6 +1132,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1195,6 +1206,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
@@ -1268,6 +1280,7 @@
     },
     {
       "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 10,


### PR DESCRIPTION
This PR backports the fixes to the Kafka Exporter and Bridge Grafana dashboards related to https://issues.redhat.com/browse/ENTMQST-4779.