### PR TITLE
Update OLM channels of Streams

### DIFF
--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -23,7 +23,7 @@ labels:
   - name: "operators.operatorframework.io.bundle.package.v1"
     value: "amq-streams"
   - name: "operators.operatorframework.io.bundle.channels.v1"
-    value: "stable,amq-streams-2.x,amq-streams-2.3.x"
+    value: "amq-streams-2.3.x"
   - name: "operators.operatorframework.io.bundle.channel.default.v1"
     value: "stable"
   - name: "com.redhat.delivery.operator.bundle"

--- a/operator-metadata/metadata/annotations.yaml
+++ b/operator-metadata/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.9
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,amq-streams-2.x,amq-streams-2.3.x
+  operators.operatorframework.io.bundle.channels.v1: amq-streams-2.3.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
Now that we support two AMQ Streams releases at the same time which are installable via OLM, we must employ the "fancy channeling" technique on our released bundle channels.
Once Streams 2.4.0 is released, we cannot ship Streams 2.3.x releases to the stableand amq-streams-2.x channels anymore because they would have a lower semver than what is at the head of those channels.