### PR TITLE
Add systemtest gating for aarch64

### DIFF
--- a/bridge/gating.yaml
+++ b/bridge/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/drain-cleaner/gating.yaml
+++ b/drain-cleaner/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/kafka/kafka-3.4.0/gating.yaml
+++ b/kafka/kafka-3.4.0/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/kafka/kafka-3.5.0/gating.yaml
+++ b/kafka/kafka-3.5.0/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/operator-metadata/gating.yaml
+++ b/operator-metadata/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/operator/gating.yaml
+++ b/operator/gating.yaml
@@ -11,3 +11,4 @@ rules:
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}


### PR DESCRIPTION
This PR adds gating for aarch64 - new arch supported by AMQ Streams from 2.5.0