### PR TITLE
Add bundle automation

### DIFF
--- a/operator-metadata/automation/README.md
+++ b/operator-metadata/automation/README.md
@@ -1,0 +1,15 @@
+# Container build automation scripts
+
+Automation scripts:
+- Update bundle metadata with proper versioning and pull specs of new container builds
+- Sync metadata between internal and external source repositories
+
+## CPaaS execution workflow
+
+These automation scripts are executed as part of the CPaaS container build pipeline
+ 
+```
+(1) CPaaS builds container images
+(2) CPaaS executes these automation scripts, updating bundle metadata 
+(3) CPaaS builds bundle image using updated bundle metadata 
+```

--- a/operator-metadata/automation/__init__.py
+++ b/operator-metadata/automation/__init__.py
@@ -1,0 +1,2 @@
+# automation/__init__.py
+from . import modules

--- a/operator-metadata/automation/main.py
+++ b/operator-metadata/automation/main.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from modules import constants
+from modules.file import File
+from modules.bundle_automation import BundleAutomation
+
+import koji as brew
+import os
+
+def main():
+  brew_client = brew.ClientSession(os.environ['BREW_URL'])
+
+  csv_file = File(os.environ['DIST_GIT_CSV_FILE_PATH'])
+  component_data = BundleAutomation.collect_component_build_info()
+  product_version = BundleAutomation.get_product_version(csv_file.data)
+
+  # Get old to new sha mappings
+  sha_dict = BundleAutomation.create_sha_dict(brew_client, csv_file.data, component_data)
+  bundle_versions = BundleAutomation.generate_bundle_version_strings(
+          brew_client, 
+          csv_file.data, 
+          BundleAutomation.new_pull_specs_exist(sha_dict)
+  )
+
+  # Update CSV with new shas + bump bundle version
+  csv_file.data = BundleAutomation.update_csv_data(csv_file.data, bundle_versions, sha_dict)
+  csv_file.write(os.environ['DIST_GIT_CSV_FILE_PATH'])
+  csv_file.write(os.environ['GIT_HUB_CSV_FILE_PATH'])
+
+  print(
+    "Product version:", product_version, 
+    "Old bundle version", bundle_versions[constants.OLD_BUNDLE_VERSION_INDEX], 
+    "New bundle version:", bundle_versions[constants.NEW_BUNDLE_VERSION_INDEX]
+  )
+
+  with open("csv_version", 'w') as sources:
+    sources.write(bundle_versions[constants.NEW_BUNDLE_VERSION_INDEX])
+
+if __name__ == "__main__":
+  main()

--- a/operator-metadata/automation/modules/__init__.py
+++ b/operator-metadata/automation/modules/__init__.py
@@ -1,0 +1,4 @@
+# automation/modules/__init__.py
+from . import bundle_automation
+from . import constants
+from . import file

--- a/operator-metadata/automation/modules/bundle_automation.py
+++ b/operator-metadata/automation/modules/bundle_automation.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""########################################################
+ FILE: bundle_automation.py
+########################################################"""
+import yaml
+import os
+import re
+import json
+from . import constants
+
+
+class BundleAutomation:
+
+    @staticmethod
+    def get_product_version(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['spec']['version'].split("-")[0]
+
+    @staticmethod
+    def get_replace_version(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['spec']['replaces'].split(".v")[-1]
+
+    @staticmethod
+    def get_bundle_version(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['spec']['version']
+
+    @staticmethod
+    def get_bundle_name(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['metadata']['name']
+
+    @staticmethod
+    def get_bundle_deployment_name(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['spec']['install']['spec']['deployments'][0]['name']
+
+    @staticmethod
+    def get_skip_range(csv_data):
+        data = yaml.safe_load(csv_data)
+        return data['metadata']['annotations']['olm.skipRange']
+
+    @staticmethod
+    def extract_version(name):
+        return name.split("v")[-1]
+
+    @staticmethod
+    def is_build_released(brew_client, build):
+        tags = brew_client.listTags(build)
+        for tag in tags:
+            if tag['name'] == constants.RELEASE_TAG:
+                return True
+        return False
+
+    @staticmethod
+    def decrement_minor_version(semver):
+        semver_split = semver.split(".")
+        semver_split[1] = str(int(semver_split[1]) - 1)
+        return ".".join(semver_split)
+
+    @staticmethod
+    def increment_build_version(semver):
+        semver_split = semver.split("-")
+        semver_split[-1] = str(int(semver_split[-1]) + 1)
+        return "-".join(semver_split)
+
+    @staticmethod
+    def set_build_version(semver, build_version):
+        major_minor_micro = semver.split("-")[0]
+        return major_minor_micro + "-" + str(build_version)
+
+    @staticmethod
+    def is_bundle_released(brew_client, product_version):
+        # Sort to get latest build for version
+        builds = brew_client.listBuilds(prefix=constants.METADATA_PACKAGE_NAME, queryOpts={'order': 'creation_ts'})
+        # Reverse so latest build appear first
+        builds.reverse()
+
+        for build in builds:
+            # Since the builds are in order take the latest build which matches the major and minor version
+            if build['version'] == product_version:
+                if BundleAutomation.is_build_released(brew_client, build):
+                    return True
+        return False
+
+    """
+    Gets nvr of latest brew build with the specified prefix e.g. amqstreams-operator-container-1.4.0-5
+    """
+    @staticmethod
+    def get_nvr(brew_client, prefix, version):
+        # Sort to get latest build for version
+        builds = brew_client.listBuilds(prefix=prefix, queryOpts={'order': 'creation_ts'})
+        # Reverse so latest build appear first
+        builds.reverse()
+
+        for build in builds:
+            if build['version'] == version and build['state'] == constants.COMPLETED and "source" not in build['nvr']:
+                if "openjdk-" in prefix:
+                    if BundleAutomation.is_build_released(brew_client, build):
+                        return build['nvr']
+                else:
+                    print(build['nvr'])
+                    return build['nvr']
+
+        raise ValueError('No NVR found in brew with prefix %s and version %s' % (prefix, version))
+
+    @staticmethod
+    def get_pull_spec_from_info(info):
+        data = yaml.safe_load(info)
+        return data["extra"]["image"]["index"]["digests"]["application/vnd.docker.distribution.manifest.list.v2+json"]
+
+    @staticmethod
+    def get_pull_spec_from_brew(brew_client, nvr):
+        pull_spec = None
+        try:
+            # Get Manifest List Digest associated with nvr
+            pull_spec = brew_client.getBuild(nvr)['extra']['image']['index']['digests'][
+                'application/vnd.docker.distribution.manifest.list.v2+json']
+
+            # Get Image Digest associated with nvr
+            # sha = brew_client.listArchives(brew_client.getBuild(nvr)
+            # ['build_id'])[0]['extra']['docker']['digests']['application/vnd.docker.distribution.manifest.v2+json']
+
+            print("NVR:", nvr)
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}. No NVR found in brew with value", nvr)
+
+        return pull_spec
+
+    @staticmethod
+    def format_sha(s):
+        return s.split(":")[-1]
+
+    @staticmethod
+    def get_start_interval(v):
+        # Convert version to int
+        v = int(v.split("-")[0].replace(".", ""))
+        n = int((v - 10) / 10)
+        n = ".".join(list(str(n) + "0")) + "-0"
+        return n
+
+    ''' 
+    Parses build information stored in ENV VARs from builds executed in earlier stage in pipeline:
+    
+    'CONTAINER_BUILDS_OPERATOR_BUILD_INFO_JSON'
+    'CONTAINER_BUILDS_BRIDGE_BUILD_INFO_JSON'
+    'CONTAINER_BUILDS_DRAIN_CLEANER_BUILD_INFO_JSON'
+    'CONTAINER_BUILDS_KAFKA_34_BUILD_INFO_JSON'
+    'CONTAINER_BUILDS_KAFKA_35_BUILD_INFO_JSON'
+  
+    and returns a list of dictionaries in the following format:
+  
+    {
+      'amqstreams-operator-container': '{BUILD_INFO_JSON}'
+      'amqstreams-bridge-container': '{BUILD_INFO_JSON}'
+      'amqstreams-drain-cleaner-container': '{BUILD_INFO_JSON}'
+      'amqstreams-kafka-34-container': '{BUILD_INFO_JSON}'
+      'amqstreams-kafka-35-container': '{BUILD_INFO_JSON}'
+    }
+    '''
+    @staticmethod
+    def collect_component_build_info():
+        print(" ===== COLLECTING COMPONENT BUILD INFO ===== ")
+        components = {}
+
+        for k, v in os.environ.items():
+            if k.startswith("CONTAINER_BUILDS") and k.endswith("BUILD_INFO_JSON"):
+                info = json.loads(v)
+                components[info["package_name"]] = v
+
+        return components
+
+    @staticmethod
+    def get_maven_builder_pull_spec(brew_client, csv_data):
+        product_version = BundleAutomation.get_bundle_version(csv_data).split("-")[0]
+
+        if int(product_version.split(".")[0]) <= 2 and int(product_version.split(".")[1]) < 2:
+            package_name = "openjdk-11-ubi8"
+            version = "1.10"
+        elif int(product_version.split(".")[0]) <= 2 and int(product_version.split(".")[1]) < 5:
+            package_name = "openjdk-11-ubi8"
+            version = "1.13"
+        else:
+            package_name = "openjdk-17-ubi8"
+            version = "1.16"
+
+        pull_spec = BundleAutomation.get_pull_spec_from_brew(
+            brew_client,
+            BundleAutomation.get_nvr(brew_client, package_name, version)
+        )
+        return pull_spec
+
+    @staticmethod
+    def generate_package_name(related_images_name):
+        if related_images_name == "strimzi-cluster-operator":
+            return constants.OPERATOR_PACKAGE_NAME
+        elif related_images_name == "strimzi-maven-builder":
+            return constants.STRIMZI_MAVEN_BUILDER + constants.PACKAGE_NAME_SUFFIX
+        else:
+            package_name = related_images_name.replace("strimzi", "amqstreams")
+            # If Kafka image name e.g. strimzi-kafka-340
+            # format version in generated nvr name
+            if "kafka" in package_name:
+                sep = package_name.split("-")
+                # e.g. strimzi-kafka-340 -> strimzi-kafka-34
+                sep[-1] = sep[-1][:2]
+                package_name = "-".join(sep)
+
+            package_name = package_name + constants.PACKAGE_NAME_SUFFIX
+            return package_name
+
+    @staticmethod
+    def create_sha_dict(brew_client, csv_data, components):
+        sha_dict = {}
+        print("--- Replacing SHAs with latest NVRs ---")
+
+        csv_data_yaml = yaml.safe_load(csv_data)
+        for entry in csv_data_yaml["spec"]["relatedImages"]:
+            name = entry['name']
+            image = entry['image']
+
+            package_name = BundleAutomation.generate_package_name(name)
+            if name == constants.STRIMZI_MAVEN_BUILDER:
+                pull_spec = BundleAutomation.get_maven_builder_pull_spec(brew_client, csv_data)
+            else:
+                pull_spec = BundleAutomation.get_pull_spec_from_info(components.get(package_name))
+
+            old_sha = BundleAutomation.format_sha(image)
+            new_sha = BundleAutomation.format_sha(pull_spec)
+
+            print("OLD:", old_sha)
+            print("NEW:", new_sha)
+            print("")
+            sha_dict[old_sha] = new_sha
+
+        return sha_dict
+
+    '''
+    Returns list with the bundle version to be replaced 
+    and the current bundle version respectively
+  
+    e.g. [2.5.0-0, 2.5.0-1]
+    '''
+    @staticmethod
+    def generate_bundle_version_strings(brew_client, csv_data, new_pull_specs_exist):
+        old_bundle_version = BundleAutomation.get_replace_version(csv_data)
+        new_bundle_version = BundleAutomation.get_bundle_version(csv_data)
+
+        released = BundleAutomation.is_bundle_released(brew_client, new_bundle_version.split("-")[0])
+        if released and new_pull_specs_exist:
+            old_bundle_version = new_bundle_version
+            new_bundle_version = BundleAutomation.increment_build_version(new_bundle_version)
+
+        print("Updating " + old_bundle_version + " -> " + new_bundle_version)
+
+        return [old_bundle_version, new_bundle_version]
+
+    @staticmethod
+    def new_pull_specs_exist(sha_dict):
+        for k, v in sha_dict.items():
+            if k != v:
+                return True
+        return False
+
+    @staticmethod
+    def update_csv_data(csv_data, bundle_versions, sha_dict):
+        old_bundle_version = bundle_versions[0]
+        new_bundle_version = bundle_versions[1]
+
+        for old_sha, new_sha in sha_dict.items():
+            csv_data = csv_data.replace(old_sha, new_sha)
+
+        csv_data = csv_data.replace(old_bundle_version, new_bundle_version)
+
+        start_interval = BundleAutomation.get_start_interval(new_bundle_version)
+        csv_data = re.sub(r"olm.skipRange: '>=\d.\d.\d-\d <\d.\d.\d-\d'",
+                          "olm.skipRange: '>=" + start_interval + " <" + new_bundle_version + "'", csv_data)
+        csv_data = re.sub(r'replaces: amqstreams.v.*..*..*', 'replaces: amqstreams.v' + old_bundle_version, csv_data)
+
+        return csv_data

--- a/operator-metadata/automation/modules/constants.py
+++ b/operator-metadata/automation/modules/constants.py
@@ -1,0 +1,9 @@
+RELEASE_TAG = "rhaos-middleware-rhel-8-container-released"
+OPERATOR_PACKAGE_NAME = "amqstreams-operator-container"
+METADATA_PACKAGE_NAME = "amqstreams-bundle-container"
+PACKAGE_NAME_SUFFIX = "-container"
+STRIMZI_MAVEN_BUILDER = "strimzi-maven-builder"
+RELEASED = False
+COMPLETED = 1
+OLD_BUNDLE_VERSION_INDEX=0
+NEW_BUNDLE_VERSION_INDEX=1

--- a/operator-metadata/automation/modules/file.py
+++ b/operator-metadata/automation/modules/file.py
@@ -1,0 +1,19 @@
+class File:
+  def __init__(self, path):
+    with open(path, 'r') as file:
+      self.data = file.read().rstrip()
+    self.path = path
+
+  def get_data(self):
+    return self.data
+
+  def get_path(self):
+    return self.path
+
+  def write(self):
+    with open(self.path, 'w') as sources:
+      sources.write(self.data)
+
+  def write(self, path):
+    with open(path, 'w') as sources:
+      sources.write(self.data)

--- a/operator-metadata/automation/tests/__init__.py
+++ b/operator-metadata/automation/tests/__init__.py
@@ -1,0 +1,1 @@
+# automation/tests/__init__.py

--- a/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_BRIDGE_BUILD_INFO_JSON
+++ b/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_BRIDGE_BUILD_INFO_JSON
@@ -1,0 +1,165 @@
+{
+  "creation_time": "2023-09-21 16:50:02.465743",
+  "start_ts": 1695314940,
+  "completion_time": "2023-09-21 16:56:36.378407",
+  "volume_id": 0,
+  "owner_id": 6716,
+  "release": "5",
+  "volume_name": "DEFAULT",
+  "epoch": null,
+  "task_id": 55684539,
+  "package_id": 73239,
+  "source": "https://<PLACEHOLDER>/git/containers/amqstreams-bridge#c41d30ce0aef4cb93d33c03f4ee5486219f05f21",
+  "extra": {
+    "image": {
+      "help": "help.md",
+      "parent_images": [
+        "registry.redhat.io/ubi8/ubi-minimal"
+      ],
+      "parent_build_id": 2674212,
+      "odcs": {
+        "compose_ids": [
+          2379147,
+          2379148,
+          2379149,
+          2379150
+        ],
+        "signing_intent": "release",
+        "signing_intent_overridden": false
+      },
+      "isolated": false,
+      "parent_image_builds": {
+        "registry.redhat.io/ubi8/ubi-minimal:latest": {
+          "id": 2674212,
+          "nvr": "ubi8-minimal-container-8.8-1072"
+        }
+      },
+      "index": {
+        "floating_tags": [
+          "latest",
+          "2.5.0"
+        ],
+        "pull": [
+          "<PLACEHOLDER>/rh-osbs/amq-streams-bridge-rhel8@sha256:c50a8977fcaaa855305ccaf96fd608504dcab9520f6a793ffc64946d3afc7059",
+          "<PLACEHOLDER>/rh-osbs/amq-streams-bridge-rhel8:2.5.0-5"
+        ],
+        "digests": {
+          "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:c50a8977fcaaa855305ccaf96fd608504dcab9520f6a793ffc64946d3afc7059"
+        },
+        "unique_tags": [
+          "amqstreams-2.5-rhel-8-containers-candidate-69674-20230921164909"
+        ],
+        "tags": [
+          "2.5.0-5"
+        ]
+      },
+      "media_types": [
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json"
+      ]
+    },
+    "submitter": "osbs",
+    "typeinfo": {
+      "image": {
+        "help": "help.md",
+        "parent_images": [
+          "registry.redhat.io/ubi8/ubi-minimal"
+        ],
+        "parent_build_id": 2674212,
+        "odcs": {
+          "compose_ids": [
+            2379147,
+            2379148,
+            2379149,
+            2379150
+          ],
+          "signing_intent": "release",
+          "signing_intent_overridden": false
+        },
+        "isolated": false,
+        "parent_image_builds": {
+          "registry.redhat.io/ubi8/ubi-minimal:latest": {
+            "id": 2674212,
+            "nvr": "ubi8-minimal-container-8.8-1072"
+          }
+        },
+        "index": {
+          "floating_tags": [
+            "latest",
+            "2.5.0"
+          ],
+          "pull": [
+            "<PLACEHOLDER>/rh-osbs/amq-streams-bridge-rhel8@sha256:c50a8977fcaaa855305ccaf96fd608504dcab9520f6a793ffc64946d3afc7059",
+            "<PLACEHOLDER>/rh-osbs/amq-streams-bridge-rhel8:2.5.0-5"
+          ],
+          "digests": {
+            "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:c50a8977fcaaa855305ccaf96fd608504dcab9520f6a793ffc64946d3afc7059"
+          },
+          "unique_tags": [
+            "amqstreams-2.5-rhel-8-containers-candidate-69674-20230921164909"
+          ],
+          "tags": [
+            "2.5.0-5"
+          ]
+        },
+        "media_types": [
+          "application/vnd.docker.distribution.manifest.list.v2+json",
+          "application/vnd.docker.distribution.manifest.v1+json",
+          "application/vnd.docker.distribution.manifest.v2+json"
+        ]
+      },
+      "icm": {
+        "archives": [
+          "icm-ppc64le.json",
+          "icm-s390x.json",
+          "icm-aarch64.json",
+          "icm-x86_64.json"
+        ],
+        "name": "icm"
+      },
+      "remote-source-file": {
+        "no_source": [
+          {
+            "checksums": {
+              "md5": "77f53ca7868e429f26fa7fe60aaccd0b"
+            },
+            "filename": "kafka-bridge-0.26.0.redhat-00004.zip",
+            "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-kafka-bridge/0.26.0.redhat_00004/1/maven/io/strimzi/kafka-bridge/0.26.0.redhat-00004/kafka-bridge-0.26.0.redhat-00004.zip"
+          },
+          {
+            "checksums": {
+              "md5": "77e0e2329e90a3d88a4ab611a53bc9e5"
+            },
+            "filename": "kafka-bridge-licenses-0.26.0.redhat-00004.tar.gz",
+            "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-kafka-bridge/0.26.0.redhat_00004/1/maven/io/strimzi/kafka-bridge-licenses/0.26.0.redhat-00004/kafka-bridge-licenses-0.26.0.redhat-00004.tar.gz"
+          }
+        ]
+      }
+    },
+    "container_koji_task_id": 55684539,
+    "osbs_build": {
+      "engine": "podman",
+      "kind": "container_build",
+      "subtypes": []
+    },
+    "custom_user_metadata": {
+      "cpaas_pipeline_id": "b0763a81-ae3a-44b2-9d3d-40ff4268e97e"
+    }
+  },
+  "creation_ts": 1695314940,
+  "id": 2688314,
+  "state": 1,
+  "cpaas_skip_build": true,
+  "owner_name": "exd-cpaas-bot-prod",
+  "nvr": "amqstreams-bridge-container-2.5.0-5",
+  "creation_event_id": 53779911,
+  "version": "2.5.0",
+  "start_time": "2023-09-21 16:50:02.459600",
+  "build_id": 2688314,
+  "cg_id": 1,
+  "name": "amqstreams-bridge-container",
+  "package_name": "amqstreams-bridge-container",
+  "completion_ts": 1695315460,
+  "cg_name": "atomic-reactor"
+}

--- a/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_DRAIN_CLEANER_BUILD_INFO_JSON
+++ b/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_DRAIN_CLEANER_BUILD_INFO_JSON
@@ -1,0 +1,137 @@
+{
+    "creation_time": "2023-09-21 16:49:52.879927",
+    "start_ts": 1.69531494E9,
+    "completion_time": "2023-09-21 16:55:58.877380",
+    "volume_id": 0,
+    "owner_id": 6716,
+    "release": "3",
+    "volume_name": "DEFAULT",
+    "epoch": null,
+    "task_id": 55684536,
+    "package_id": 81109,
+    "source": "https://<PLACEHOLDER>/git/containers/amqstreams-drain-cleaner#5a36164fde8374b24765657f155f4cb3c65ff12d",
+    "extra":     {
+        "image":         {
+            "help": "help.md",
+            "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+            "parent_build_id": 2674212,
+            "odcs":             {
+                "compose_ids":                 [
+                    2379143,
+                    2379144,
+                    2379145,
+                    2379146
+                ],
+                "signing_intent": "release",
+                "signing_intent_overridden": false
+            },
+            "isolated": false,
+            "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":             {
+                "id": 2674212,
+                "nvr": "ubi8-minimal-container-8.8-1072"
+            }},
+            "index":             {
+                "floating_tags":                 [
+                    "latest",
+                    "2.5.0"
+                ],
+                "pull":                 [
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-drain-cleaner-rhel8@sha256:14135caf67b4f88cabf113634ccec4e8c695c79c0ba05a6b3fa41758d7347415",
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-drain-cleaner-rhel8:2.5.0-3"
+                ],
+                "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:14135caf67b4f88cabf113634ccec4e8c695c79c0ba05a6b3fa41758d7347415"},
+                "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-41573-20230921164905"],
+                "tags": ["2.5.0-3"]
+            },
+            "media_types":             [
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.v2+json"
+            ]
+        },
+        "submitter": "osbs",
+        "typeinfo":         {
+            "image":             {
+                "help": "help.md",
+                "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+                "parent_build_id": 2674212,
+                "odcs":                 {
+                    "compose_ids":                     [
+                        2379143,
+                        2379144,
+                        2379145,
+                        2379146
+                    ],
+                    "signing_intent": "release",
+                    "signing_intent_overridden": false
+                },
+                "isolated": false,
+                "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":                 {
+                    "id": 2674212,
+                    "nvr": "ubi8-minimal-container-8.8-1072"
+                }},
+                "index":                 {
+                    "floating_tags":                     [
+                        "latest",
+                        "2.5.0"
+                    ],
+                    "pull":                     [
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-drain-cleaner-rhel8@sha256:14135caf67b4f88cabf113634ccec4e8c695c79c0ba05a6b3fa41758d7347415",
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-drain-cleaner-rhel8:2.5.0-3"
+                    ],
+                    "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:14135caf67b4f88cabf113634ccec4e8c695c79c0ba05a6b3fa41758d7347415"},
+                    "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-41573-20230921164905"],
+                    "tags": ["2.5.0-3"]
+                },
+                "media_types":                 [
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                    "application/vnd.docker.distribution.manifest.v1+json",
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ]
+            },
+            "icm":             {
+                "archives":                 [
+                    "icm-s390x.json",
+                    "icm-ppc64le.json",
+                    "icm-aarch64.json",
+                    "icm-x86_64.json"
+                ],
+                "name": "icm"
+            },
+            "remote-source-file": {"no_source":             [
+                                {
+                    "checksums": {"md5": "3cad76275a27274d8c90d92e4dfa65f3"},
+                    "filename": "strimzi-drain-cleaner-0.3.1.redhat-00005-runner.jar",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi-drain-cleaner/0.3.1.redhat_00005/1/maven/io/strimzi/strimzi-drain-cleaner/0.3.1.redhat-00005/strimzi-drain-cleaner-0.3.1.redhat-00005-runner.jar"
+                },
+                                {
+                    "checksums": {"md5": "b0fbe258112388c295d7ffea480dd1ca"},
+                    "filename": "strimzi-drain-cleaner-licenses-0.3.1.redhat-00005.tar.gz",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi-drain-cleaner/0.3.1.redhat_00005/1/maven/io/strimzi/strimzi-drain-cleaner-licenses/0.3.1.redhat-00005/strimzi-drain-cleaner-licenses-0.3.1.redhat-00005.tar.gz"
+                }
+            ]}
+        },
+        "container_koji_task_id": 55684536,
+        "osbs_build":         {
+            "engine": "podman",
+            "kind": "container_build",
+            "subtypes": []
+        },
+        "custom_user_metadata": {"cpaas_pipeline_id": "b0763a81-ae3a-44b2-9d3d-40ff4268e97e"}
+    },
+    "creation_ts": 1.69531494E9,
+    "id": 2688313,
+    "state": 1,
+    "cpaas_skip_build": true,
+    "owner_name": "exd-cpaas-bot-prod",
+    "nvr": "amqstreams-drain-cleaner-container-2.5.0-3",
+    "creation_event_id": 53779910,
+    "version": "2.5.0",
+    "start_time": "2023-09-21 16:49:52.876597",
+    "build_id": 2688313,
+    "cg_id": 1,
+    "name": "amqstreams-drain-cleaner-container",
+    "package_name": "amqstreams-drain-cleaner-container",
+    "completion_ts": 1.69531533E9,
+    "cg_name": "atomic-reactor"
+}

--- a/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_KAFKA_34_BUILD_INFO_JSON
+++ b/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_KAFKA_34_BUILD_INFO_JSON
@@ -1,0 +1,142 @@
+{
+    "creation_time": "2023-09-21 16:50:05.889805",
+    "start_ts": 1.69531494E9,
+    "completion_time": "2023-09-21 16:58:11.444666",
+    "volume_id": 0,
+    "owner_id": 6716,
+    "release": "5",
+    "volume_name": "DEFAULT",
+    "epoch": null,
+    "task_id": 55684538,
+    "package_id": 84345,
+    "source": "https://<PLACEHOLDER>/git/containers/amqstreams-kafka-34#0b205c5e26275e34bcfd0e8bca94fea364ea7963",
+    "extra":     {
+        "image":         {
+            "help": "help.md",
+            "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+            "parent_build_id": 2674212,
+            "odcs":             {
+                "compose_ids":                 [
+                    2379152,
+                    2379154,
+                    2379156,
+                    2379158
+                ],
+                "signing_intent": "release",
+                "signing_intent_overridden": false
+            },
+            "isolated": false,
+            "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":             {
+                "id": 2674212,
+                "nvr": "ubi8-minimal-container-8.8-1072"
+            }},
+            "index":             {
+                "floating_tags":                 [
+                    "latest",
+                    "2.5.0"
+                ],
+                "pull":                 [
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-34-rhel8@sha256:cc8932404394383a5db36478a3b898ee6d81de00febd46050ccfb6efa6d177c0",
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-34-rhel8:2.5.0-5"
+                ],
+                "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:cc8932404394383a5db36478a3b898ee6d81de00febd46050ccfb6efa6d177c0"},
+                "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-35497-20230921164906"],
+                "tags": ["2.5.0-5"]
+            },
+            "media_types":             [
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.v2+json"
+            ]
+        },
+        "submitter": "osbs",
+        "typeinfo":         {
+            "image":             {
+                "help": "help.md",
+                "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+                "parent_build_id": 2674212,
+                "odcs":                 {
+                    "compose_ids":                     [
+                        2379152,
+                        2379154,
+                        2379156,
+                        2379158
+                    ],
+                    "signing_intent": "release",
+                    "signing_intent_overridden": false
+                },
+                "isolated": false,
+                "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":                 {
+                    "id": 2674212,
+                    "nvr": "ubi8-minimal-container-8.8-1072"
+                }},
+                "index":                 {
+                    "floating_tags":                     [
+                        "latest",
+                        "2.5.0"
+                    ],
+                    "pull":                     [
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-34-rhel8@sha256:cc8932404394383a5db36478a3b898ee6d81de00febd46050ccfb6efa6d177c0",
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-34-rhel8:2.5.0-5"
+                    ],
+                    "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:cc8932404394383a5db36478a3b898ee6d81de00febd46050ccfb6efa6d177c0"},
+                    "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-35497-20230921164906"],
+                    "tags": ["2.5.0-5"]
+                },
+                "media_types":                 [
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                    "application/vnd.docker.distribution.manifest.v1+json",
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ]
+            },
+            "icm":             {
+                "archives":                 [
+                    "icm-x86_64.json",
+                    "icm-ppc64le.json",
+                    "icm-s390x.json",
+                    "icm-aarch64.json"
+                ],
+                "name": "icm"
+            },
+            "remote-source-file": {"no_source":             [
+                                {
+                    "checksums": {"md5": "bb8c40391c032a5a830c1eca82f77150"},
+                    "filename": "streams-ocp-34-2.5.0.redhat-00004.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/com.redhat.amq-amq-streams-dist/2.5.0.redhat_00004/1/maven/com/redhat/amq/streams-ocp-34/2.5.0.redhat-00004/streams-ocp-34-2.5.0.redhat-00004.zip"
+                },
+                                {
+                    "checksums": {"md5": "0db7599c34c5241f305da3adc6a79460"},
+                    "filename": "strimzi-kafka-scripts-0.36.0.redhat-00004.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/strimzi-kafka-scripts/0.36.0.redhat-00004/strimzi-kafka-scripts-0.36.0.redhat-00004.zip"
+                },
+                                {
+                    "checksums": {"md5": "39e2322892f4003772c2f07daa366b6c"},
+                    "filename": "cruise-control-ocp-2.5.0.redhat-00004-ocp.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/com.redhat.amq-amq-streams-dist/2.5.0.redhat_00004/1/maven/com/redhat/amq/cruise-control-ocp/2.5.0.redhat-00004/cruise-control-ocp-2.5.0.redhat-00004-ocp.zip"
+                }
+            ]}
+        },
+        "container_koji_task_id": 55684538,
+        "osbs_build":         {
+            "engine": "podman",
+            "kind": "container_build",
+            "subtypes": []
+        },
+        "custom_user_metadata": {"cpaas_pipeline_id": "b0763a81-ae3a-44b2-9d3d-40ff4268e97e"}
+    },
+    "creation_ts": 1.69531494E9,
+    "id": 2688315,
+    "state": 1,
+    "cpaas_skip_build": true,
+    "owner_name": "exd-cpaas-bot-prod",
+    "nvr": "amqstreams-kafka-34-container-2.5.0-5",
+    "creation_event_id": 53779912,
+    "version": "2.5.0",
+    "start_time": "2023-09-21 16:50:05.885390",
+    "build_id": 2688315,
+    "cg_id": 1,
+    "name": "amqstreams-kafka-34-container",
+    "package_name": "amqstreams-kafka-34-container",
+    "completion_ts": 1.69531546E9,
+    "cg_name": "atomic-reactor"
+}

--- a/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_KAFKA_35_BUILD_INFO_JSON
+++ b/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_KAFKA_35_BUILD_INFO_JSON
@@ -1,0 +1,142 @@
+{
+    "creation_time": "2023-09-21 16:50:09.184349",
+    "start_ts": 1.69531507E9,
+    "completion_time": "2023-09-21 16:58:05.464741",
+    "volume_id": 0,
+    "owner_id": 6716,
+    "release": "5",
+    "volume_name": "DEFAULT",
+    "epoch": null,
+    "task_id": 55684537,
+    "package_id": 84757,
+    "source": "https://<PLACEHOLDER>/git/containers/amqstreams-kafka-35#8806433863650636225557b303cd4e8b30ba2ded",
+    "extra":     {
+        "image":         {
+            "help": "help.md",
+            "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+            "parent_build_id": 2674212,
+            "odcs":             {
+                "compose_ids":                 [
+                    2379159,
+                    2379160,
+                    2379161,
+                    2379162
+                ],
+                "signing_intent": "release",
+                "signing_intent_overridden": false
+            },
+            "isolated": false,
+            "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":             {
+                "id": 2674212,
+                "nvr": "ubi8-minimal-container-8.8-1072"
+            }},
+            "index":             {
+                "floating_tags":                 [
+                    "latest",
+                    "2.5.0"
+                ],
+                "pull":                 [
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-35-rhel8@sha256:b7ba3bf3943cd8ccf78ee12372bf7e412fd18ccf1caf0c9ebe7c4434065f22c8",
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-35-rhel8:2.5.0-5"
+                ],
+                "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:b7ba3bf3943cd8ccf78ee12372bf7e412fd18ccf1caf0c9ebe7c4434065f22c8"},
+                "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-39021-20230921164905"],
+                "tags": ["2.5.0-5"]
+            },
+            "media_types":             [
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.v2+json"
+            ]
+        },
+        "submitter": "osbs",
+        "typeinfo":         {
+            "image":             {
+                "help": "help.md",
+                "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+                "parent_build_id": 2674212,
+                "odcs":                 {
+                    "compose_ids":                     [
+                        2379159,
+                        2379160,
+                        2379161,
+                        2379162
+                    ],
+                    "signing_intent": "release",
+                    "signing_intent_overridden": false
+                },
+                "isolated": false,
+                "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":                 {
+                    "id": 2674212,
+                    "nvr": "ubi8-minimal-container-8.8-1072"
+                }},
+                "index":                 {
+                    "floating_tags":                     [
+                        "latest",
+                        "2.5.0"
+                    ],
+                    "pull":                     [
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-35-rhel8@sha256:b7ba3bf3943cd8ccf78ee12372bf7e412fd18ccf1caf0c9ebe7c4434065f22c8",
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-kafka-35-rhel8:2.5.0-5"
+                    ],
+                    "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:b7ba3bf3943cd8ccf78ee12372bf7e412fd18ccf1caf0c9ebe7c4434065f22c8"},
+                    "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-39021-20230921164905"],
+                    "tags": ["2.5.0-5"]
+                },
+                "media_types":                 [
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                    "application/vnd.docker.distribution.manifest.v1+json",
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ]
+            },
+            "icm":             {
+                "archives":                 [
+                    "icm-x86_64.json",
+                    "icm-aarch64.json",
+                    "icm-ppc64le.json",
+                    "icm-s390x.json"
+                ],
+                "name": "icm"
+            },
+            "remote-source-file": {"no_source":             [
+                                {
+                    "checksums": {"md5": "0c40e449314ad6dee80685cbdf0cdebf"},
+                    "filename": "streams-ocp-35-2.5.0.redhat-00004.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/com.redhat.amq-amq-streams-dist/2.5.0.redhat_00004/1/maven/com/redhat/amq/streams-ocp-35/2.5.0.redhat-00004/streams-ocp-35-2.5.0.redhat-00004.zip"
+                },
+                                {
+                    "checksums": {"md5": "0db7599c34c5241f305da3adc6a79460"},
+                    "filename": "strimzi-kafka-scripts-0.36.0.redhat-00004.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/strimzi-kafka-scripts/0.36.0.redhat-00004/strimzi-kafka-scripts-0.36.0.redhat-00004.zip"
+                },
+                                {
+                    "checksums": {"md5": "39e2322892f4003772c2f07daa366b6c"},
+                    "filename": "cruise-control-ocp-2.5.0.redhat-00004-ocp.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/com.redhat.amq-amq-streams-dist/2.5.0.redhat_00004/1/maven/com/redhat/amq/cruise-control-ocp/2.5.0.redhat-00004/cruise-control-ocp-2.5.0.redhat-00004-ocp.zip"
+                }
+            ]}
+        },
+        "container_koji_task_id": 55684537,
+        "osbs_build":         {
+            "engine": "podman",
+            "kind": "container_build",
+            "subtypes": []
+        },
+        "custom_user_metadata": {"cpaas_pipeline_id": "b0763a81-ae3a-44b2-9d3d-40ff4268e97e"}
+    },
+    "creation_ts": 1.69531507E9,
+    "id": 2688316,
+    "state": 1,
+    "cpaas_skip_build": true,
+    "owner_name": "exd-cpaas-bot-prod",
+    "nvr": "amqstreams-kafka-35-container-2.5.0-5",
+    "creation_event_id": 53779913,
+    "version": "2.5.0",
+    "start_time": "2023-09-21 16:50:09.180421",
+    "build_id": 2688316,
+    "cg_id": 1,
+    "name": "amqstreams-kafka-35-container",
+    "package_name": "amqstreams-kafka-35-container",
+    "completion_ts": 1.69531546E9,
+    "cg_name": "atomic-reactor"
+}

--- a/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_OPERATOR_BUILD_INFO_JSON
+++ b/operator-metadata/automation/tests/resources/CONTAINER_BUILDS_OPERATOR_BUILD_INFO_JSON
@@ -1,0 +1,157 @@
+{
+    "creation_time": "2023-09-21 16:50:16.993299",
+    "start_ts": 1.69531507E9,
+    "completion_time": "2023-09-21 16:58:10.842641",
+    "volume_id": 0,
+    "owner_id": 6716,
+    "release": "5",
+    "volume_name": "DEFAULT",
+    "epoch": null,
+    "task_id": 55684540,
+    "package_id": 73236,
+    "source": "https://<PLACEHOLDER>/git/containers/amqstreams-operator#37c9c5d6bcab5168b8677954ccbce86ca6880a53",
+    "extra":     {
+        "image":         {
+            "help": "help.md",
+            "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+            "parent_build_id": 2674212,
+            "odcs":             {
+                "compose_ids":                 [
+                    2379163,
+                    2379164,
+                    2379165,
+                    2379168
+                ],
+                "signing_intent": "release",
+                "signing_intent_overridden": false
+            },
+            "isolated": false,
+            "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":             {
+                "id": 2674212,
+                "nvr": "ubi8-minimal-container-8.8-1072"
+            }},
+            "index":             {
+                "floating_tags":                 [
+                    "latest",
+                    "2.5.0"
+                ],
+                "pull":                 [
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-strimzi-rhel8-operator@sha256:d1d05b73b7f9c150bdfcce7854fcc62968a964617bcc1be7d133c68d0d31aa5d",
+                    "<PLACEHOLDER>/rh-osbs/amq-streams-strimzi-rhel8-operator:2.5.0-5"
+                ],
+                "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:d1d05b73b7f9c150bdfcce7854fcc62968a964617bcc1be7d133c68d0d31aa5d"},
+                "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-52766-20230921164909"],
+                "tags": ["2.5.0-5"]
+            },
+            "media_types":             [
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.v2+json"
+            ]
+        },
+        "submitter": "osbs",
+        "typeinfo":         {
+            "image":             {
+                "help": "help.md",
+                "parent_images": ["registry.redhat.io/ubi8/ubi-minimal"],
+                "parent_build_id": 2674212,
+                "odcs":                 {
+                    "compose_ids":                     [
+                        2379163,
+                        2379164,
+                        2379165,
+                        2379168
+                    ],
+                    "signing_intent": "release",
+                    "signing_intent_overridden": false
+                },
+                "isolated": false,
+                "parent_image_builds": {"registry.redhat.io/ubi8/ubi-minimal:latest":                 {
+                    "id": 2674212,
+                    "nvr": "ubi8-minimal-container-8.8-1072"
+                }},
+                "index":                 {
+                    "floating_tags":                     [
+                        "latest",
+                        "2.5.0"
+                    ],
+                    "pull":                     [
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-strimzi-rhel8-operator@sha256:d1d05b73b7f9c150bdfcce7854fcc62968a964617bcc1be7d133c68d0d31aa5d",
+                        "<PLACEHOLDER>/rh-osbs/amq-streams-strimzi-rhel8-operator:2.5.0-5"
+                    ],
+                    "digests": {"application/vnd.docker.distribution.manifest.list.v2+json": "sha256:d1d05b73b7f9c150bdfcce7854fcc62968a964617bcc1be7d133c68d0d31aa5d"},
+                    "unique_tags": ["amqstreams-2.5-rhel-8-containers-candidate-52766-20230921164909"],
+                    "tags": ["2.5.0-5"]
+                },
+                "media_types":                 [
+                    "application/vnd.docker.distribution.manifest.list.v2+json",
+                    "application/vnd.docker.distribution.manifest.v1+json",
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ]
+            },
+            "icm":             {
+                "archives":                 [
+                    "icm-ppc64le.json",
+                    "icm-s390x.json",
+                    "icm-x86_64.json",
+                    "icm-aarch64.json"
+                ],
+                "name": "icm"
+            },
+            "remote-source-file": {"no_source":             [
+                                {
+                    "checksums": {"md5": "2cee4977ba16eb31217af773baa9f910"},
+                    "filename": "cluster-operator-0.36.0.redhat-00004-dist.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/cluster-operator/0.36.0.redhat-00004/cluster-operator-0.36.0.redhat-00004-dist.zip"
+                },
+                                {
+                    "checksums": {"md5": "3b9a2c62054179a0c6da0a76d7bad0dc"},
+                    "filename": "topic-operator-0.36.0.redhat-00004-dist.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/topic-operator/0.36.0.redhat-00004/topic-operator-0.36.0.redhat-00004-dist.zip"
+                },
+                                {
+                    "checksums": {"md5": "c883a2201afe53ddbecede29ac03e6bd"},
+                    "filename": "user-operator-0.36.0.redhat-00004-dist.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/user-operator/0.36.0.redhat-00004/user-operator-0.36.0.redhat-00004-dist.zip"
+                },
+                                {
+                    "checksums": {"md5": "2a51d419dee6f1c7b8467adae2d75745"},
+                    "filename": "kafka-init-0.36.0.redhat-00004-dist.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/kafka-init/0.36.0.redhat-00004/kafka-init-0.36.0.redhat-00004-dist.zip"
+                },
+                                {
+                    "checksums": {"md5": "472a71abc369ee0bf867ff7ad185d966"},
+                    "filename": "strimzi-licenses-0.36.0.redhat-00004.tar.gz",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/strimzi-licenses/0.36.0.redhat-00004/strimzi-licenses-0.36.0.redhat-00004.tar.gz"
+                },
+                                {
+                    "checksums": {"md5": "0bd156cdb7e2b3237f05fd64c43a23ec"},
+                    "filename": "strimzi-operator-scripts-0.36.0.redhat-00004.zip",
+                    "url": "http://<PLACEHOLDER>/brewroot/packages/io.strimzi-strimzi/0.36.0.redhat_00004/1/maven/io/strimzi/strimzi-operator-scripts/0.36.0.redhat-00004/strimzi-operator-scripts-0.36.0.redhat-00004.zip"
+                }
+            ]}
+        },
+        "container_koji_task_id": 55684540,
+        "osbs_build":         {
+            "engine": "podman",
+            "kind": "container_build",
+            "subtypes": []
+        },
+        "custom_user_metadata": {"cpaas_pipeline_id": "b0763a81-ae3a-44b2-9d3d-40ff4268e97e"}
+    },
+    "creation_ts": 1.69531507E9,
+    "id": 2688318,
+    "state": 1,
+    "cpaas_skip_build": true,
+    "owner_name": "exd-cpaas-bot-prod",
+    "nvr": "amqstreams-operator-container-2.5.0-5",
+    "creation_event_id": 53779916,
+    "version": "2.5.0",
+    "start_time": "2023-09-21 16:50:16.985339",
+    "build_id": 2688318,
+    "cg_id": 1,
+    "name": "amqstreams-operator-container",
+    "package_name": "amqstreams-operator-container",
+    "completion_ts": 1.69531546E9,
+    "cg_name": "atomic-reactor"
+}

--- a/operator-metadata/automation/tests/resources/test.bundle.clusterserviceversion.yaml
+++ b/operator-metadata/automation/tests/resources/test.bundle.clusterserviceversion.yaml
@@ -1,0 +1,1435 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples-metadata: |-
+      {
+        "my-cluster": {
+          "description": "Example Kafka cluster with Ephemeral storage"
+        },
+        "my-connect-cluster": {
+          "description": "Example Kafka Connect cluster"
+        },
+        "my-mirror-maker": {
+          "description": "Example Kafka Mirror Maker 1 deployment"
+        },
+        "my-mm2-cluster": {
+          "description": "Example Kafka Mirror Maker 2 deployment"
+        },
+        "my-bridge": {
+          "description": "Example AMQ Streams Kafka HTTP Bridge deployment"
+        },
+        "my-topic": {
+          "description": "Example KafkaTopic custom resource"
+        },
+        "my-user": {
+          "description": "Example KafkaUser custom resource"
+        },
+        "my-source-connector": {
+          "description": "Example Kafka Connect source connector"
+        },
+        "my-rebalance": {
+          "description": "Example Cruise Control rebalance request"
+        },
+        "my-pool": {
+          "description": "Example KafkaNodePool custom resource"
+        }
+      }
+    alm-examples: |-
+      [
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"Kafka",
+          "metadata":{
+            "name":"my-cluster"
+          },
+          "spec":{
+            "kafka":{
+                "version":"3.5.0",
+                "replicas":3,
+                "listeners": [
+                  {
+                    "name": "plain",
+                    "port": 9092,
+                    "type": "internal",
+                    "tls": false
+                  },
+                  {
+                    "name": "tls",
+                    "port": 9093,
+                    "type": "internal",
+                    "tls": true
+                  }
+                ],
+                "config":{
+                  "offsets.topic.replication.factor":3,
+                  "transaction.state.log.replication.factor":3,
+                  "transaction.state.log.min.isr":2,
+                  "default.replication.factor":3,
+                  "min.insync.replicas":2,
+                  "inter.broker.protocol.version":"3.5"
+                },
+                "storage":{
+                  "type":"ephemeral"
+                }
+            },
+            "zookeeper":{
+                "replicas":3,
+                "storage":{
+                  "type":"ephemeral"
+                }
+            },
+            "entityOperator":{
+                "topicOperator":{
+                  },
+                "userOperator":{
+                  }
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"KafkaConnect",
+          "metadata":{
+            "name":"my-connect-cluster"
+          },
+          "spec":{
+            "version":"3.5.0",
+            "replicas":1,
+            "bootstrapServers":"my-cluster-kafka-bootstrap:9093",
+            "tls":{
+                "trustedCertificates":[
+                  {
+                      "secretName":"my-cluster-cluster-ca-cert",
+                      "certificate":"ca.crt"
+                  }
+                ]
+            },
+            "config": {
+                "group.id": "connect-cluster",
+                "offset.storage.topic": "connect-cluster-offsets",
+                "config.storage.topic": "connect-cluster-configs",
+                "status.storage.topic": "connect-cluster-status",
+                "config.storage.replication.factor": -1,
+                "offset.storage.replication.factor": -1,
+                "status.storage.replication.factor": -1
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"KafkaMirrorMaker",
+          "metadata":{
+            "name":"my-mirror-maker"
+          },
+          "spec":{
+            "version":"3.5.0",
+            "replicas":1,
+            "consumer":{
+                "bootstrapServers":"my-source-cluster-kafka-bootstrap:9092",
+                "groupId":"my-source-group-id"
+            },
+            "producer":{
+                "bootstrapServers":"my-target-cluster-kafka-bootstrap:9092"
+            },
+            "include":".*"
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"KafkaBridge",
+          "metadata":{
+            "name":"my-bridge"
+          },
+          "spec":{
+            "replicas":1,
+            "bootstrapServers":"my-cluster-kafka-bootstrap:9092",
+            "http":{
+                "port":8080
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"KafkaTopic",
+          "metadata":{
+            "name":"my-topic",
+            "labels":{
+                "strimzi.io/cluster":"my-cluster"
+            }
+          },
+          "spec":{
+            "partitions":10,
+            "replicas":3,
+            "config":{
+                "retention.ms":604800000,
+                "segment.bytes":1073741824
+            }
+          }
+        },
+        {
+          "apiVersion":"kafka.strimzi.io/v1beta2",
+          "kind":"KafkaUser",
+          "metadata":{
+            "name":"my-user",
+            "labels":{
+                "strimzi.io/cluster":"my-cluster"
+            }
+          },
+          "spec":{
+            "authentication":{
+                "type":"tls"
+            },
+            "authorization":{
+                "type":"simple",
+                "acls":[
+                  {
+                      "resource":{
+                        "type":"topic",
+                        "name":"my-topic",
+                        "patternType":"literal"
+                      },
+                      "operations":["Read", "Describe", "Write", "Create"],
+                      "host":"*"
+                  },
+                  {
+                      "resource":{
+                        "type":"group",
+                        "name":"my-group",
+                        "patternType":"literal"
+                      },
+                      "operations":["Read"],
+                      "host":"*"
+                  }
+                ]
+            }
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1beta2",
+          "kind": "KafkaConnector",
+          "metadata": {
+            "name": "my-source-connector",
+            "labels": {
+              "strimzi.io/cluster": "my-connect-cluster"
+            }
+          },
+          "spec": {
+            "class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+            "tasksMax": 1,
+            "config": {
+              "file": "/opt/kafka/LICENSE",
+              "topic": "my-topic"
+            }
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1beta2",
+          "kind": "KafkaMirrorMaker2",
+          "metadata": {
+            "name": "my-mm2-cluster"
+          },
+          "spec": {
+            "version":"3.4.0",
+            "replicas": 1,
+            "connectCluster": "cluster-b",
+            "clusters": [
+              {
+                "alias": "cluster-a",
+                "bootstrapServers": "cluster-a-kafka-bootstrap:9092"
+              },
+              {
+                "alias": "cluster-b",
+                "bootstrapServers": "cluster-b-kafka-bootstrap:9092",
+                "config": {
+                  "config.storage.replication.factor": -1,
+                  "offset.storage.replication.factor": -1,
+                  "status.storage.replication.factor": -1
+                }
+              }
+            ],
+            "mirrors": [
+              {
+                "sourceCluster": "cluster-a",
+                "targetCluster": "cluster-b",
+                "sourceConnector": {
+                  "config": {
+                    "replication.factor": -1,
+                    "offset-syncs.topic.replication.factor": -1,
+                    "sync.topic.acls.enabled": "false"
+                  }
+                },
+                "checkpointConnector": {
+                  "config": {
+                    "checkpoints.topic.replication.factor": -1
+                  }
+                },
+                "topicsPattern": ".*",
+                "groupsPattern": ".*"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1beta2",
+          "kind": "KafkaRebalance",
+          "metadata": {
+            "name": "my-rebalance",
+            "labels": {
+              "strimzi.io/cluster": "my-cluster"
+            }
+          },
+          "spec": {
+            "goals": [
+              "CpuCapacityGoal",
+              "NetworkInboundCapacityGoal",
+              "DiskCapacityGoal",
+              "RackAwareGoal",
+              "MinTopicLeadersPerBrokerGoal",
+              "NetworkOutboundCapacityGoal",
+              "ReplicaCapacityGoal"
+            ]
+          }
+        },
+        {
+          "apiVersion": "core.strimzi.io/v1beta2",
+          "kind": "StrimziPodSet",
+          "metadata": {
+            "name": "strimzi-pod-set-example"
+          },
+          "spec": {
+            "pods": [
+              {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                  "labels": {
+                    "app": "strimzi-pod-set-example"
+                  },
+                  "name": "example-pod"
+                },
+                "spec": {
+                  "containers": [
+                    {
+                      "command": [
+                        "sleep",
+                        3600
+                      ],
+                      "image": "busybox:latest",
+                      "imagePullPolicy": "IfNotPresent",
+                      "name": "busybox"
+                    }
+                  ]
+                }
+              }
+            ],
+            "selector": {
+              "matchLabels": {
+                "app": "strimzi-pod-set-example"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "kafka.strimzi.io/v1beta2",
+          "kind": "KafkaNodePool",
+          "metadata": {
+            "name": "my-pool",
+            "labels": {
+              "strimzi.io/cluster": "my-cluster"
+            }
+          },
+          "spec": {
+            "replicas": 3,
+            "roles": [
+              "broker"
+            ],
+            "storage": {
+              "type": "jbod",
+              "volumes": [
+                {
+                  "id": 0,
+                  "type": "persistent-claim",
+                  "size": "100Gi",
+                  "deleteClaim": false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: Streaming & Messaging
+    certified: 'false'
+    containerImage: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+    createdAt: 2023-07-10 21:47:00
+    description: Red Hat AMQ Streams is a massively scalable, distributed, and high performance data streaming platform based on Apache Kafka®.
+    repository: https://github.com/strimzi/strimzi-kafka-operator
+    support: Red Hat
+    operators.openshift.io/infrastructure-features: |-
+      ["Disconnected", "Proxy", "proxy-aware", "fips"]
+    operators.openshift.io/valid-subscription: |-
+      ["Red Hat AMQ", "Red Hat Application Foundations"]
+    operators.operatorframework.io/internal-objects: |-
+      ["strimzipodsets.core.strimzi.io"]
+    olm.skipRange: '>=2.4.0-0 <2.5.0-0'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+  name: amqstreams.v2.5.0-0
+  namespace: placeholder
+spec:
+  MinKubeVersion: 1.21.0
+  customresourcedefinitions:
+    owned:
+    - description: Represents a Kafka cluster
+      displayName: Kafka
+      kind: Kafka
+      name: kafkas.kafka.strimzi.io
+      resources:
+      - kind: Route
+        name: ''
+        version: route.openshift.io/v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: Secret
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Kafka version
+        displayName: Version
+        path: kafka.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The desired number of Kafka brokers.
+        displayName: Kafka Brokers
+        path: kafka.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The type of storage used by Kafka brokers
+        displayName: Kafka storage
+        path: kafka.storage.type
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+          - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+          - urn:alm:descriptor:com.tectonic.ui:select:jbod
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Kafka Resource Requirements
+        path: kafka.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: The desired number of Zookeeper nodes.
+        displayName: Zookeeper Nodes
+        path: zookeeper.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The type of storage used by Zookeeper nodes
+        displayName: Zookeeper storage
+        path: zookeeper.storage.type
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+          - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+          - urn:alm:descriptor:com.tectonic.ui:select:jbod
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Zookeeper Resource Requirements
+        path: zookeeper.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Cluster ID
+        displayName: Cluster ID
+        path: clusterId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Kafka cluster conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a pool of Kafka brokers
+      displayName: Kafka Node Pool
+      kind: KafkaNodePool
+      name: kafkanodepools.kafka.strimzi.io
+      resources:
+      - kind: Route
+        name: ''
+        version: route.openshift.io/v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: Secret
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka brokers in this pool.
+        displayName: Kafka Brokers
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The type of storage used by this pool of Kafka nodes
+        displayName: Kafka storage
+        path: storage.type
+        x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:ephemeral
+          - urn:alm:descriptor:com.tectonic.ui:select:persistent-claim
+          - urn:alm:descriptor:com.tectonic.ui:select:jbod
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Kafka Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Cluster ID
+        displayName: Cluster ID
+        path: clusterId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: List of node IDs in this Node Pool
+        displayName: Node IDs
+        path: nodeIds
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Kafka cluster conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a Kafka Connect cluster
+      displayName: Kafka Connect
+      kind: KafkaConnect
+      name: kafkaconnects.kafka.strimzi.io
+      resources:
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka Connect nodes.
+        displayName: Connect nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka Connect version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The address of the bootstrap server
+        displayName: Bootstrap server
+        path: bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Connect conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a Kafka MirrorMaker cluster
+      displayName: Kafka Mirror Maker
+      kind: KafkaMirrorMaker
+      name: kafkamirrormakers.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka MirrorMaker nodes.
+        displayName: MirrorMaker nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka Mirror Maker version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The bootstrap address of the Source cluster
+        displayName: Source cluster
+        path: consumer.bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The bootstrap address of the Target cluster
+        displayName: Target cluster
+        path: producer.bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Expression specifying the topics which should be mirrored
+        displayName: Mirrored topics
+        path: include
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka MirrorMaker conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a Kafka Bridge cluster
+      displayName: Kafka Bridge
+      kind: KafkaBridge
+      name: kafkabridges.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka Bridge nodes.
+        displayName: Bridge nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The bootstrap address of the Kafka cluster
+        displayName: Kafka cluster
+        path: bootstrapServers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The port where the HTTP Bridge is listening
+        displayName: HTTP port
+        path: http.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka Bridge conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a topic inside a Kafka cluster
+      displayName: Kafka Topic
+      kind: KafkaTopic
+      name: kafkatopics.kafka.strimzi.io
+      specDescriptors:
+      - description: The number of partitions
+        displayName: Partitions
+        path: partitions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The number of replicas
+        displayName: Replication factor
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Kafka topic conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a user inside a Kafka cluster
+      displayName: Kafka User
+      kind: KafkaUser
+      name: kafkausers.kafka.strimzi.io
+      resources:
+      - kind: Secret
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: Authentication type
+        displayName: Authentication type
+        path: authentication.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:tls
+        - urn:alm:descriptor:com.tectonic.ui:select:scram-sha-512
+      - description: Authorization type
+        displayName: Authorization type
+        path: authorization.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:simple
+      statusDescriptors:
+      - description: Kafka user conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a Connector inside a Kafka Connect cluster
+      displayName: Kafka Connector
+      kind: KafkaConnector
+      name: kafkaconnectors.kafka.strimzi.io
+      specDescriptors:
+      - description: Class of the Kafka Connect connector
+        displayName: Class
+        path: class
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Maximum number of tasks used by the connector
+        displayName: Max number of tasks
+        path: tasksMax
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - description: Connector conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Represents a Kafka MirrorMaker 2 cluster
+      displayName: Kafka MirrorMaker 2
+      kind: KafkaMirrorMaker2
+      name: kafkamirrormaker2s.kafka.strimzi.io
+      resources:
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kafka MirrorMaker 2 nodes.
+        displayName: MirrorMaker2 nodes
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Kafka MirrorMaker 2 version
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: The Kafka cluster where the underlying Kafka Connect connects
+        displayName: Connect cluster
+        path: connectCluster
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limits describes the minimum/maximum amount of compute resources
+          required/allowed
+        displayName: Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      statusDescriptors:
+      - description: Kafka MirrorMaker conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Triggeres rebalance of replicas in a Kafka cluster
+      displayName: Kafka Rebalance
+      kind: KafkaRebalance
+      name: kafkarebalances.kafka.strimzi.io
+      resources: []
+      specDescriptors:
+      - description: Skip hard Cruise Cotnrol goals
+        displayName: Skip hard goals
+        path: 'skipHardGoalCheck'
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      statusDescriptors:
+      - description: Kafka Rebalance conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1beta2
+    - description: Internal custom resource used to manage Strimzi pods
+      displayName: Strimzi Pod Set
+      kind: StrimziPodSet
+      name: strimzipodsets.core.strimzi.io
+      resources: []
+      specDescriptors:
+      - description: Selector used to match pods managed by this resource
+        displayName: Pod Selector
+        path: 'selector'
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod'
+      statusDescriptors:
+      - displayName: Pods
+        description: Number of desired pods
+        path: pods
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - displayName: Ready Pods
+        description: Number of pods which are ready
+        path: readyPods
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - displayName: Up-to-date Pods
+        description: Number of pods which are up-to-date
+        path: currentPods
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      version: v1beta2
+  description: >
+    **Red Hat AMQ Streams** is a massively scalable, distributed, and high performance data streaming platform based on the Apache Kafka® project.
+    AMQ Streams provides an event streaming backbone that allows microservices and other application components to exchange data with extremely high throughput and low latency.
+
+    **From the 2.5.0 release, AMQ Streams supports only OCP 4.10 to 4.13!
+
+    **The core capabilities include:**
+    * A pub/sub messaging model, similar to a traditional enterprise messaging system, in which application components publish and consume events to/from an ordered stream
+    
+    * The long term, fault-tolerant storage of events
+    
+    * The ability for a consumer to replay streams of events
+    
+    * The ability to partition topics for horizontal scalability
+    
+    ### Upgrades
+
+    **!!! IMPORTANT !!!**
+    **Direct upgrade from AMQ Stream 1.7 or earlier is not supported!**
+    You have to upgrade first to one of the previous versions of AMQ Streams.
+    You will also need to convert the CRD resources.
+    For more information, see the [documentation for AMQ Streams on OpenShift](https://access.redhat.com/documentation/en-us/red_hat_amq_streams/).
+    
+
+    ### Supported Features
+
+    * **Manages the Kafka Cluster** - Deploys and manages all of the components of this complex application, including dependencies like Apache ZooKeeper® that are traditionally hard to administer.
+
+    * **Includes Kafka Connect** - Allows for configuration of common data sources and sinks to move data into and out of the Kafka cluster.
+
+    * **Topic Management** - Creates and manages Kafka Topics within the cluster.
+
+    * **User Management** - Creates and manages Kafka Users within the cluster.
+
+    * **Connector Management** - Creates and manages Kafka Connect connectors.
+
+    * **Includes Kafka Mirror Maker 1 and 2** - Allows for mirroring data between different Apache Kafka® clusters.
+
+    * **Includes HTTP Kafka Bridge** - Allows clients to send and receive messages through an Apache Kafka® cluster via HTTP protocol.
+
+    * **Cluster Rebalancing** - Uses built-in Cruise Control for redistributing partition replicas according to specified goals in order to achieve the best cluster performance.
+
+    * **Monitoring** - Built-in support for monitoring using Prometheus and provided Grafana dashboards
+
+    ### Upgrading your Clusters
+    
+    The AMQ Streams Operator understands how to run and upgrade between a set of Kafka versions.
+    When specifying a new version in your config, check to make sure you aren't using any features that may have been removed.
+    For more information on upgrading, see the [documentation for AMQ Streams on OpenShift](https://access.redhat.com/documentation/en-us/red_hat_amq_streams/).
+
+    ### Storage
+
+    An efficient data storage infrastructure is essential to the optimal performance of Apache Kafka®.
+    Apache Kafka® deployed via AMQ Streams requires block storage.
+    The use of file storage (for example, NFS) is not recommended.
+    
+    The AMQ Streams Operator supports three types of data storage:
+    
+    * Ephemeral (Recommended for development only!)
+    
+    * Persistent
+    
+    * JBOD (Just a Bunch of Disks, suitable for Kafka only. Not supported in Zookeeper.)
+    
+    AMQ Streams also supports advanced operations such as adding or removing disks in Apache Kafka® brokers or resizing the persistent volumes (where supported by the infrastructure).
+
+    ### Documentation
+
+    Documentation for the current release can be found on the Red Hat [Customer Portal](https://access.redhat.com/documentation/en-us/red_hat_amq_streams).
+
+  displayName: AMQ Streams
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAIj5JREFUeNrsnX1wVOW9x5/dBBIgLxvAKFFkGape0Zo4tFNfppLcueKlRQlzi0A7HRKsdG5va5Iy3r96b7Ktf9w71Ztgp+OI1Sx3Wt/wDol2ZLRqFjuibaEktmClRQJULOElGxKSAHm553dyTrpJNpvz9pzzPOd8vzPbDUKzZ3fP5/v8fr/neX5PiEHS6qPrWUR5KtP+WK49L1EeUe3n1L+3qnblkdR+7lQex7WfE/rf33xi/O8hyRTCRyAF6GUa1PRcqoFdLthlJjSj6NBMo1MxhnZ8ezAAyDzs5RroZQ6M4J6qcMOW9qJvfqd94MC+jv7f/jpx3VO7YAowACgF+HIN+JUCjur24P9aFVv0RPOE/3bpsML/rNmJ4XNde/s/2Ju4qq4hgbsABhDEEX6t34CfCf50uvLXTjYy0J8Y+vR4a/LlZkQIMABfQl+pjfCV7O8FOhZ0+NPpcudfOofPn2np2RXfu+i/drTg7oEByAz9Wg36SFDetx34p0QHJz5JhnLntPS99Vpr0Te+DTOAAUgR3tcEDXoe8Kczg0t/PtwyOjiwvWDNg0gTYADCQE+gV2ngR4P6OfCEf7IG2n/TmRVZsP2TlTfEsQYBBuAV+OXK02YN/kDLTfhTNXIhyUYGB+LJ53fsxGwCDMAt8An4+iCP9iLAP1lUPLx06GBMSQ/i+FZgADzC/FotzI/gExEL/lQN93QnL33Usf3EhoompAcwALvgRzXoqwC++PBPNoLR/ovx5EvPblfSg058YzAAs+DXI7+XE/7JdYLLx4/G+97+ZQxGAAMwGurX49OQH/7JRhAuiMT+tCSE1AAGgBw/SPCjRgADyAR/FUNVPxDwTzCC5PnO/vfeDvysQSjA4NOqvUbm4w05gN+AEZw7k+j/IFEX1NWFoQCCH9FG/FqgHWz4dfV3/Y31dp1u6v5qWSxoaUEoYPDTGv1m5PmAX9fg4CDr7e1Vfx69kEwOf3q8umTlvS0wAH+BH9XAR7gP+NPCPyEt+OTjxOW3Xq1e8oMfd8IA5Idfn9bDqM8ZfiWXVqfbBg93TPjvWQWFLGd5GctVHuGCiNDwpyh5Zd/bsWsrNzXBAOTN9Xdj1OcHP7X36n2zlfW90aJAb6yGNuu6KJt7RznLv28ty1tVKSr84xrpPpcIFy1YV1xcnIQBINcH/Ip6Xomz7me3G4Z+OmUp0UDRQ7Vs/pYa1yIDM/Dr8nNtIOQz8FHh5wh/35st7HSsTu3j56TcMgIr8E+IBk6f8t1MQchH8Jdpo34ZcHYWfsrrP9tWrYT7fAdASg/oOihFEA3+FLVTgfC6r3+rHQaAkN/38FNh79OH17HhC+4NegvrGtjC2noR4ddFH0Z1cXGx9ClB2Afw02q+3YDfefgp1z+xocJV+ElnGxvUiENQ+Jl2r+3+2x/aG2W/B7Ilz/dR5ecIv1MQWhG9PsnOWgRO8I/ryu/erdVSz3Wy1gXCksJPH3ob4Pcn/E5cB2/4L/3yRdbX8AjT7sE27Z6UTlkSwk8f+B6G3Xtc4Ke5/VPf3cRGLw0Kcb3qUWKhkKnCoIvw67pGeWz8biH7zU971BOUpVFIMvir2FixD+IAP1X7Kee3O7/PQ9e/1GbIBDyAf7KqlXQgjhTAefgbAD8/+Ennn9suJPwkI6mAAPCTmrV7FSmAg/DTnYvFPRzhp8U9NN0nqig6yZQKCAK/rnIlHYgq6UArIgBn4K8CxvzgJ51tjAn/XrqfbRozArHh11Wl3bswAMAvNvw0+uvTbiKL1iNMvk5B4ZfGBMKCgh9RHgcBP3/4ST2v7JTmfZ1/drss8KeawEFt3QoMwAj8bGyOH2v6XYBfNYBdcWneG0UrNDUoCfy6ynpHWNu7JeKZgIgRAOB3EX6Cyendfbx15tWXZIKfKfCzwZGxxWuimYBQBqDlS4DfJfhJtNlHNl367a9lg388EmBjy9dhANPAj5zfRfhVA3h/r3Tv9cqB92SEX1e5EgU0wwAAv+fwk9ze6eeUho78UUb4dVWJYgJhAeBvAPzewC9rCkAa7b0gK/ypJtAYaANIOZYL8gB+mTXy2QmZ4ddVq5hAVSANQNvVh7X9gN+aAZw6KTv8upoVE6gMlAFoe6d3A2PA75UEgT/VBMoCYQDaQh/07wP8tpR1461+gZ9d/WBV5M5D53aPjo5GfG8A2siPuX5B4KdOvDIqlF/oF/jZjY3NLDsyPzpw9OM2XxuA1sCzHCiLM/LLagDZN97iG/h1zVl2U1lvx/5mXxqA1robe/oFC/vn3imfH9PobzYCEB1+XXm3rai6+PGhKl8ZQMqhHZBgOX/u8lLpPpNZK+7yJfzjpnzj8sYzr71c5gsDQNFPXPjVEWdVpXSfy+zy1b6FX1Nk4Zr1zW5sHHIjAqCFPij6CQh/6mtJZQArV/sZfl1lX/r9qUapDQB5v/jwq6+3frM0n03O/RsN5f+Swz9mdFcvqurt2F8ppQGkhP6QwPCrOecd5dLMBuSs2RgI+MdTtNtWNB9/oiEqnQEwnNcnBfy6FtaJvyVj1oq7ZywA+gl+vR6waPN3mqUyAGX0p7C/HEjLAb/++jyO5XY0Utn2o6DBP2Z8C64qP//O67VSGIACP4Ur2OEnEfzjN2y9uIfd5m7ayrIzLP/1K/y6iipW1/NIBXhEAJjykxB+Nb9eXiakCRD487Y9Flj4eaYCjp4NqFX9scvPZfipqWffmy3sysnjaY/2otV+tOCHQvxwwczeTMdwiXJOAFX8C57ePe3oHxD4x9V/5HD1vJtuiQtnAFrV/xhGf3fgH9EOyaA++Wa6+pIJ0LTfTHP/natv9/ycQMCfVtTDbWkoFEqKZgAUO2LOnzP8BD4d4knHZNnp50fTflT5n84IvD4pGPBPr8unP4vnXFNSLYwBaGv9DwJtvvBTD/+/PrzO0T7+FBFc98zuaVMDL9IBwD+zet5PVETuqkjY/T1OFQEbgTZf+AnCY0pY7vQhHtQU9OjdS1VzSSe6XioMZhW4k9nRXH/Rq/sB/0zGfdOtjjBnOwLQGntixR9n+Gkk5ikC/PqX2tSZgHQi46Fr4NVFmEb9edt+lHGlH+CfoupQKBT3zAC0wh+F/lEgLi/8Rk1AjxjoKHGnjIDAn7NpqzrPn2mNP+CfqqGe7mR2YZGtgqBdA2hgWPTDDX6CjApxbopMYNl7x2acLqSUgWYg6BqtpCW0pVd9rFw94+YewJ9RMcUAGlw3AEz78YWfqvA8cn4jyl9Vya59xthyjoGBAZb8/Qds6MA+9bQeatc9/NmJCW27Ka8fe75LbeZJz0Y7+gD+GWVrWjDbxgvXAn4+8JMozPbq1N7eN1vUkX2mvQF0RHdfX59asMu20aUX8NtSpO/DA1QQtJQnWooAtPX+x4A5H/gJfKrMeylaJ0CpQCb4JTyi22/wp4qiANMjhtVpQOT9nOAn9byy0/P3QSY0XaEP8IunkZERS0yaNgBt9K8C6nzgVw1gV1yI99OzayfglwD+oaEhdvZ4Z9XhHz4adSMCqAHq/OCn6rpXuf9k0QYjwC8+/MlkkoXy8lnePavquRqAVvnH6M8JfvWmfbNVmPdFew30NADwiwv/6Oio+ufZi6NVXV1dEW4GwFD55wo/qf/9hFDvjyISwC8+/CrMY1OrpjbkmZ0GRPjPEX7SyIWkUO/xYtdpNgT4uYiiq/4P9k74b0b6NqSDPyVqq3m3hDXdc4oZupEMTwNizT9/+El/WhIS6n3SIh7amQf4nTN4I9u56f6i7dqTuzVngj9F1cXFxXGnUwBM/XGGP0gKIvxUVKX1HWcbG2bs5UB7QNR/2xQzCz8b7uk2zKohA1BG/3KGDT+AH/BbFgFNvRzMNnEhs6DNYEbhJ2UVFkU7X28pdzIC2Izb1h34c5eLdYqa2YM4AX96+O3s6FTN4wf/Zgh+XbOX3lDjiAFg6s/dkT9cINYki9ljuAH/RNGajq5Yne3fM/jCDnblwD7D/z57wVWVRhYGGYkAAL+LYT918BVJWQ5t8glqtZ9G/mGHZnb6Yt8zd98+sLHKCQOoAfzu5fz5q9YKNfo7kQIEFf5M+ymsiLZY05Zrw9HkvLzNtgxAa/YZBfzuibrxiHJQJzXsAPx2cn/nN3Vdeu1F49GbgWLgTBFADeD34LXXi5F1GTmJF/BPLx6rOoePHDJn4kuWbbZjAJWA34vX937SJVyy2Fb4j+W9jMumLuq2ZCqNy8mptGQA2jFfEcDvvsYO7Wjw9Bry6n8C+AU0gNRWa4bSgIJI5ETiV5VWIoC1gN87zd9S41ktgHJ/q6M/4J9o5I7/Tq2/ohnlLi9da8UAKgG/hyF4QcST66HKf179k4BfUAOg1MyCzEUAQQv/RV3eS7vC3Lwu/UguK4t/AH+a74/Dmg6LkVnkyFOPV5qJAFYC/mBd30zn8QF+K9/dZse/IzpHwYry7rlvrRkDqAT8wblOwM8vBZiptboZzZnh9KRMyr7q6nJDBhCUxT+y7eqj612656DjeeVMh3ECfnuie8yJg1Xp+6Hj02woevQXPyszEgGUA34xRasEqVc/TRHavamomJTX8CRyfheigOJ6ewf5qgenKt+V3Y1Z+fc+MIXtUJoIoM3PJuCX/fzUWYa2iVLr7sFpjvaebsTPuX+DrVV+gN+8zr/0HOv694dcTc8ma7j7XGLRTTdXzGQAo4BfLumbTi4d6mC9Hb9LA/1d6ohv5CBOwO+89GYel/e/p+7oM7qYh9Zj0JSsU1uyR3p72DXLbghNawBa5582wC+n0L1XXPhTm3nQ53jptZfYlQPvpR3xCXyK0JxuxkLq37+vIvqVysR4bSEI+T/gB/xeiKC/cOHClE4+BLeegqU2+QjlF3A5ZHVCNFiymBif1gBWAn7AD/idgZ9G/uHh4RlqMne5el3hOXMnMB72cwQA+AG/l/BT+C+aQtnZ5WkNQJv/B/yAH/D7FH71O2jbw94t+TvrYT+O/oAf8AP+qep59UX22X8+MoH1VAMoBfyAH/D7Hv4JrKcaQBngB/yA3/fwT2DdNwYA+AE/4DcE/1QDkL0ACPgBP+A3DL8qvRCoRwBRwA/4AX8w4E+NAsIyh/+AH/ADfkvwjw/6ugGUAn7AD/gDA/848/pS4AjgH9tVR2e4977Ryi4dbp9wpluudmJP3n1rWf6qSu6HeAJ+wM8R/vEIQN0NKNMWYB7w01bas40xU+e40XUsrKvn0vkV8AN+zvCruucUC4W047+7gwg/NdWg01t7lVHfqqg7z8LaesAP+KWCX1MR1QDKggg/hfjHVt9uC37S2cYG9unD61QzAfyAXyL4SWXhoMJ/YkOFY0c3kYnQ77NjAoAf8LsMPylCRcDyoIX9BOuwAyP2BIAVU6F04tpndgN+j+Cn75bMuP/9vaq505/pmZqpkuigjvxVa8f/HHD41QiAagANyg/1QYCfRPCbKfaZvrnrG1nRllrA7yL8BDkVcalJqhFR4Xb+QzXTfk8BgZ8UoxRgSVDgpxuEJ/xjNYGY4VQA8Nsf8btidezo3UsNw68bxmnt/zf5fggQ/KRSMoBoEODX4eQtSi2MvA7gd6aOc/65JluRA/0OMpEAwq/WAMJBgZ8W+PA4r326SAPw84ffzHkImUQmcur7m4MGvyoygIjf4Vdv4jdaXXsfFAX0TTO9CPjth/08irgX/u9/2cWWnwcKfor+hVkHwHttP+/cf8rrvb8X8HMo+P314XWOwz8eJSqf3dCRPwYF/nED8D38er7npiaHp4DfmdSKt5FfbHgkKPCPpwC+h9/t0X+y4QB+Z+RGEZciAPo8gwC/5wbg5y29ugEAfofCcxeLuIPP7wgE/J4aAPbzA35T1+ZiEZeigJHPTvoefs8MwG34c5e7X+ekY7gBv7MRgJu6nNjje/g9MQAvRn5q3sFj337G1yxZDPgdTKd4Vf4zRQF+h991A/Ay7J97R7nLEcBdgN9BA3BbI6dO+h5+Vw3A65w//761rqcAgB8SGX7XDECEgl/eqkrX0oCc+zey8KLFgB8SGn5XDECkaj/18HMl3dj6KOCXXKH8At/Dz90ARJvqo+vhPSOQu2mro6M/4He/fkPKvvFW38PP1QBEneenjj1ZnFp6003j5OgP+FOM1eWp3GwONRzR4OdmACIv8qE6wPUvtTluAqH8Qpb/xE71GfBzuKfWb3Yx/C/kMosjGvxcDECGFX7UE85JE6CRP/L8O46F/oB/qqiI65bmKGlcEOB33ABkWt5LJhDdc9B2fjm7fDUreHo34HchcqP7y43RP9dhAxAVft0A2oMG/+R0gK7b7BQhzfMXPN3C8h9H2O+WqOFqFucj2aiG49T3KTr8ijqpK3Abs9ka3C8be2jbcN8brepzunZTFOpnK7khzfM7XSUG/MZEewKoKQiXAUE19d1BgZ+UsG0AQdjVNzAwwPr6+rj9fsBvEqxX4uoZDE6KDJ3gd2r0lwB+1QAoBegE/NOLtvQCfrFU8C+bWeEPfwr47StJBnAc8E8PP7b0iiW9dXf2V9azQpp5sbnrkgp+AYWf1BEG/IBfNvj11t3q9Osv3rFUuNOLuPO2PRZU+FVRDYDy/zbAD/hlgn/K3/f2sMt796iNPK4c2Kf+OV2oz6uIKyP8itaZMgDAD/hFhD+dqKXXcMqefl79GSSGn1RBBkATq92AH/D7BX43JTH8pKIQ/a9iAqOAH/AD/kDBz+45xUJ6ETAB+AE/4A8O/ExbAawbQBLwA37AHxj4SZ2pBtAB+AE/4A8M/OPMh1PDAcAP+AF/IOCfEgF0An7AD/gDA//4oB/S/0QzAYAf8AP+QMCvzgCkRgCscMOWdsAP+AG//+FPTfnHDaDom99pB/yAH/D7Hv70BjBwYF8H4Af8gN/38JM6phhA/29/nXDr1emsN+q6Q48Rzoc+An7AD/inaJz10ARYDh0czeHUf51aOfXs2qlCP/mkV+rHl7+qkhU9VOPo8V2A375RpzuYk3r0hy325gP83ksvAE41gCOH2nJuWF7uKCSH29npWJ0KvhHRTAQ1fwzbbP4I+M2LorFexaj1voiZjuQmo6aOynToqtGW3YBfjNFfMYCKtAZw8f22BuVLdewAPau92+jmuu6Z3cxqNAL4zYN/tjGmfl/DFlIy+r7o3MVMbbsBvzCKKQbQMKUGoNYBPtib8Bp+PfQ8saFCjR4AP1/4u59rYkfvXsrOK8/DFusx9H3Rd02/J12kB/jFzP+nRACkyyePjdrNwwncY6tvt32ludoJPkbTAcBvbtSn9tpGUzMzWljXwBbW1gN+wfP/KRGAemMM9Nu+I5xq2Uy9+c8/tx3wOwy/btA84CedbWxQ7wHAL/bon9YAhj493mo39B887Nyaou5nm2acKgT85tOrdNV9R+FS7oOjq25jV7rPAX5x1DqjASRfbrY1LFAF2UkNa5VpwO9M2P+pEvYPc157MT6YHPkj64s9AvhligCue2pX++XOv1geHjLB6rSpAH7zqZmT0ZkRUZfewRd2AH7v1ank/+0zGoA66p4/Y4niS5xurnQ3LeA3aaKKMfMwZyPq3/FjtUsv4Bdr9J/WAHp2xfdaDdd5aHK+CvjNixZjeSXq0U8mAPjFyv+nNYBF/7Wj5cqJT5IivgvAb+HmfyXOveg34+f62oueRQGAnyWV8L/FsAGQQrlzTMeLTq7jTxUtOQX81tX97HYh7sKB558G/N5oWpanNYC+t15rtWIAWTbX8KcTLQgC/NbTJ7cLf9OJju4C/OKE/xkNoOgb37aUBhjdGGJGI5//AuC3qD6PCn9pv8dTJ9WpQcAvRvif0QBUMP582PTdU7h+s6NXT8c/Z315FeC3WjM5JFafl2EXDADwGwv/ZzSA0cEB08mjukXUwShg3vcfA/w2UwCRNHLqJOB3VzstG0DBmgfbB9p/Y/oOouaiTtQCZpevVh+A37p4rfe3bEgH9gF+90SLfxKWDYCUFVlgOgqg3Xu0i8+OCdD57Xn1TwJ+CPBzGv0NGcAnK2+IW+nbl6Nt5bUyNUijfsHTu1kovxDwQ4DfuuK2DeDmEyw5MjgQt/LqZAJL9xxk87fUGoscShaz/Md3qg/A70+F8gsAvztqUcL/TtsGQEo+v2On1augdKC4vpEte++Y2uuPioSpqQHN8VMrqUjjz1nRqweQ8zssfRGVKKLUDvC7IkOpe8gwQMf+fGx29HNRHleKRT78RDsAaSmwKMpreJLlrNkI+PmKin9LDQ3QhiE6dDAG+OUL++feuVKoO3PWirsBP38ZZtWwARSseTA+3NOdBPxy5fwipQAU/ocXLQb8fEWMtjhuACpQH3VsB/zywK+OuFr/fhGUc/9GwO9C7q+E/0kuBnBiQ0WTE1EA4HdXTi/PtiKa1clZswHw81eTmX9sygBoSnC0/2Ic8MsDv2oAX6vitlXbqOZs2mp5ahfwG1bczOivGrPZVzjT2BCdv6XmmJWjuwD/zKKlu9RabfhCD+t/PzHh72j6NOeWMgXmJWpYbwZq+r3UDdir0b/o1f2WDADwm9JSI3P/tgyANPDh/ubcz6+oAvz24U89j89szz79UFUK8Y0co+bVlCAt7LKyvgPwmx79TR/IYckAzEYBgD89+HbO45ssWlBFpytnOp+PXpOiADcbhOQqof+8bY8BfgFHf8sGQBodHW1QnuoBv3n4zzbF1ANPeDRRJSMo1lZcem0CVPW3sqEL8Lsz+tsygI+uZ5EbPjx/LKuwKAL4jcFPub1bvflp/wWd2Ds5SqPjurpPHmfnH7qfa3cewO+aktrob2k0CVt9VZoRyLQuAPBPurGVUJ/O43Mr/KbTficfAaaf1Tc8Zx4rfP4dNTznIQr5Ab9r2m4VflsRwHgU0HHuYFZkfhTwN2cM+enATC+UpfVmmH1zadqDOqlBR1/se4506qFlvnO3/cjShh/A7/7ob9sASBd++XJV/lfXNwP+9OqK1amjsZciEyjc0cpCn7s54+eqnuBjwQgI/DlbH1We77J0fYDfsqoV+ON2fkHIiasYOtvVlrXgqnLAPzXsd+qodLsyOhdPdQE6xGNIiQwy1QgIer1lm531/YDfstoV+G+3fV84cSVKFFCW9cUvH7wYygL8+vUquT7l/CKJQnPK/c2ITvMZTokKsm+8xbFmLYDflipm6vfnmgGQ/vaH9sbw1SW1gH9sqo3gF60jL2muEqpTuO61AL8tWZ72m6ywU1fU/dWy2OiFZDLo8JNogY+I8JMoz3frcA7Az0XEmGMnvTpmADQtOPzp8eqgw0/ge130m9EEnvgPwC+v6uxU/bkZAKlk5b0tw598nAgq/ProL7quHHiPa39+wM9NCbtVf64GQLr81qvVWpgSOPhp9Bep/14mDb7wNOCXL/R3fErJcQNY8oMfd17Z93YsaPCrN/krO6W5my4n9qgVfsAvjWJWNvu4bgCkays3NY10n0sECX71Rt8Vl+qOIhMA/NKE/lwKS2FeVxwuWrDOzKyA7PBT+C9q5T9TLQDwBzP0524AxcXFhmcF/NLJRzbxjAAAv2Oq5hH6czcAEs0KjJw+1eR3+NX3cahDyruLx5oAwO+YaMFPC88XCPN+B7RASHlq9zP8JDe77DgpJ3YBAn4uohuqjveLcDcAWiCUbmrQb917Rzh093FDww5GAIDf2bzfyQU/nhkA6bqvf6s9tZDhx9bdskYAgF9I0Wo/V26osFvvqLi4WK0HoG8/4IdmzPvjbr1Ytpvv7JrPl9V9dD2j/tXlgB/wQ1Pzfqd2+QkXAaRoHWP2wxvR4M810Jcf8EMZ1Kk8XD+5xXUDoKKgVg9I+gV+9YO0cFKSCMq2eFw34HdUxMI6N4p+IkQAZALtWiTgm7Bf1ggglF8A+L1XtVtFPyEMQDOBBDO5xFHknD/nllI5IwCTHXwBPxf4W7x68bCX71wxgbjyFJMdftJ0J/GILLPn9QF+x9XkZsVfOAPQTKBBeYrLDD+JDuqULQ2YZSL/B/yOi6b76ry+iLAIn4RiAtXTmYBMU310Sq9MylmzAfB7B78Q/eLDonwi6UxAtnn+vFWVUoX/Rtp7A37HlRAFfqEMIMUE2mWEX08DMh3PLZJyN30b8Lsvy7NfgTAATRUK/O2yrvCjE3llyP1nOsYL8HOBv8KLuX6pDIAWCinwVzCLqwW9Xt5LUcDCugah78S8hicBP+AXNgJg2gdFJpCQCX5d87fUqEYgouhkoExn+QF+53N+UeEnhUT/9N4tYUR0lSzw6xLxbEAK/Que3g343VNcpIKfNBHApGhg2ilCUeEn5SwvY4ueEOeawiWLWf7jccAP+CcoS4ZPsrmXtVbnM9ptc4cM8OuihUGzFkdZ35ut3oZ5+YWs4CcvsqyS6wG/O6IVfv8qw4VmyfKJKibwhmICx5UfK2WAfzwSuLmUDc0vZpfaXvcOfiXsn27NP+B3XLS2/79ludgsmT5ZxQTaFROg9rv/rMCfKzr8o6OjLElHIyy7WRl9F4+dx3f5kmuvT9BHnn8HI787oiLfJgX+F2W66JCMn/S7JazszkPndmdH5kdFh39oaGj8v1EL7osNj7hyPHfupq1s3rbHkPO7o042tp9fusaQIVk/cQWwyMDRj9vmLLupTAb4UzWw48ds4IUdbLS3x/HXpkr/nK2PZlzoA/gdlbBz/L42AF29Hfub825bUSUL/OP/ToF/UDEBp4yAwM+5fwPLWbMx478D/I5Kikq/rw2AdPHjQ1Vzb1zeqPwYkQH+yaJOyXRMF9UIzJgBTe3NXrlaAX+jocYegN/RfL/O6738MIAUnXnt5bKFa9ZTVbBMJvgni0yADusgIxhSny9MAD5rkfJQYM++6daMK/oAP9eQv1rGfN/XBkB6t4RFvvT7U42zr15UJSP8vAT4nQv5tZE/6Zc3FPLjt9Tbsb8y77YVzW6kBIA/MCG/p737eCnsx28rv/QLLSf+J3b7lXNnEoAf8NsU3UO3+xF+30YAqTr/zuu1RRWr652OBgB/IEb9mAJ+k5/fZNjv3+L8f/xKk9PRAOAPzKjf5Pc3GgrSt0rThbOvXtSYXVgUAfzQNKO+L6b3YADTAxzp+/BAo5XFQ4Df14ozn1X4kQKkc7xQKJlf+oVqJS2ouHL+bDvgD7z0pbzVQYM/kBGAlbQA8CPchwH4WLSA6IsfHKvNXRytYZNmCwC/L8HfzsaadiSD/mHAANLUB3Kjy6qyCyKAH3k+DCCIOv5EQ3T+P62pH4wsqBqdMw/w+wN8mtPvxEcBAzCswz98NJp3z6r62YujVWEDx2gBfoAPA/Churq6qC5QO3whWZNVEIkAfuT4MIAAioqF/9DeVTnc012fVVgUBfxCiUb5mPJoAfgwAP532+st5bOX3lCTveCqSsDvqWiTznYF+gQ+ChiAJ3WCwgc2VoXn5W3mFRUA/rSj/U421pIL+T0MQKCoYMmyzaGcnEqnagWAf0JuT6P9Toz2MADhdSLxq8rc5aVr2dhBJhHAbwv6Vr/ux4cBBEBHnnq8Mu+e+9ZmX3V1ufLHKOCfMbxPAHoYgC919Bc/K8u/94Hy4e5za0PZ2eXp1hcEEH4VeHr2S7NNGABkuG4wq2RxeXjO3JVkCL1te4IAPwG/VwMe+TwMANJFx54pT5QqlLKxFudlkr+ldu3RgREeBgBZN4UyrX5Qqj2XCQh6pwY6PbcDdhgAxNcYIpoRRFIMoZT9fdYhygwWHTNlKdqDlNQA14FPaqBj5Z2k+n8BBgCYs/pPRyOn1wAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      permissions:
+      - rules:
+        - apiGroups:
+            - "rbac.authorization.k8s.io"
+          resources:
+            # The cluster operator needs to access and manage rolebindings to grant Strimzi components cluster permissions
+            - rolebindings
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - "rbac.authorization.k8s.io"
+          resources:
+            # The cluster operator needs to access and manage roles to grant the entity operator permissions
+            - roles
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - ""
+          resources:
+            # The cluster operator needs to access and delete pods, this is to allow it to monitor pod health and coordinate rolling updates
+            - pods
+            # The cluster operator needs to access and manage service accounts to grant Strimzi components cluster permissions
+            - serviceaccounts
+            # The cluster operator needs to access and manage config maps for Strimzi components configuration
+            - configmaps
+            # The cluster operator needs to access and manage services and endpoints to expose Strimzi components to network traffic
+            - services
+            - endpoints
+            # The cluster operator needs to access and manage secrets to handle credentials
+            # The entity operator user-operator needs to access and manage secrets to store generated credentials
+            - secrets
+            # The cluster operator needs to access and manage persistent volume claims to bind them to Strimzi components for persistent data
+            - persistentvolumeclaims
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - "kafka.strimzi.io"
+          resources:
+            # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage Kafka resources
+            - kafkas
+            - kafkas/status
+            # The cluster operator runs the KafkaAssemblyOperator, which needs to access and manage KafkaNodePool resources
+            - kafkanodepools
+            - kafkanodepools/status
+            # The cluster operator runs the KafkaConnectAssemblyOperator, which needs to access and manage KafkaConnect resources
+            - kafkaconnects
+            - kafkaconnects/status
+            # The cluster operator runs the KafkaConnectorAssemblyOperator, which needs to access and manage KafkaConnector resources
+            - kafkaconnectors
+            - kafkaconnectors/status
+            # The cluster operator runs the KafkaMirrorMakerAssemblyOperator, which needs to access and manage KafkaMirrorMaker resources
+            - kafkamirrormakers
+            - kafkamirrormakers/status
+            # The cluster operator runs the KafkaBridgeAssemblyOperator, which needs to access and manage BridgeMaker resources
+            - kafkabridges
+            - kafkabridges/status
+            # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access and manage KafkaMirrorMaker2 resources
+            - kafkamirrormaker2s
+            - kafkamirrormaker2s/status
+            # The cluster operator runs the KafkaRebalanceAssemblyOperator, which needs to access and manage KafkaRebalance resources
+            - kafkarebalances
+            - kafkarebalances/status
+            # The entity operator runs the KafkaTopic assembly operator, which needs to access and manage KafkaTopic resources
+            - kafkatopics
+            - kafkatopics/status
+            # The entity operator runs the KafkaUser assembly operator, which needs to access and manage KafkaUser resources
+            - kafkausers
+            - kafkausers/status
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - "core.strimzi.io"
+          resources:
+            # The cluster operator uses StrimziPodSets to manage the Kafka and ZooKeeper pods
+            - strimzipodsets
+            - strimzipodsets/status
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - "apps"
+          resources:
+            # The cluster operator needs to access and manage deployments to run deployment based Strimzi components
+            - deployments
+            - deployments/scale
+            - deployments/status
+            # The cluster operator needs to access and manage stateful sets to run stateful sets based Strimzi components
+            - statefulsets
+            # The cluster operator needs to access replica-sets to manage Strimzi components and to determine error states
+            - replicasets
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - "" # legacy core events api, used by topic operator
+            - "events.k8s.io" # new events api, used by cluster operator
+          resources:
+            - events
+          verbs:
+            - create
+        - apiGroups:
+            # Kafka Connect Build on OpenShift requirement
+            - build.openshift.io
+          resources:
+            - buildconfigs
+            - buildconfigs/instantiate
+            - builds
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - networking.k8s.io
+          resources:
+            # The cluster operator needs to access and manage network policies to lock down communication between Strimzi components
+            - networkpolicies
+            # The cluster operator needs to access and manage ingresses which allow external access to the services in a cluster
+            - ingresses
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - route.openshift.io
+          resources:
+            # The cluster operator needs to access and manage routes to expose Strimzi components for external access
+            - routes
+            - routes/custom-host
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - image.openshift.io
+          resources:
+            # The cluster operator needs to verify the image stream when used for Kafka Connect image build
+            - imagestreams
+          verbs:
+            - get
+        - apiGroups:
+            - policy
+          resources:
+            # The cluster operator needs to access and manage pod disruption budgets this limits the number of concurrent disruptions
+            # that a Strimzi component experiences, allowing for higher availability
+            - poddisruptionbudgets
+          verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+            - patch
+            - update
+        - apiGroups:
+            - coordination.k8s.io
+          resources:
+            # The cluster operator needs to access and manage leases for leader election
+            # The "create" verb cannot be used with "resourceNames"
+            - leases
+          verbs:
+            - create
+        - apiGroups:
+            - coordination.k8s.io
+          resources:
+            # The cluster operator needs to access and manage leases for leader election
+            - leases
+          resourceNames:
+            # The default RBAC files give the operator only access to the Lease resource names strimzi-cluster-operator
+            # If you want to use another resource name or resource namespace, you have to configure the RBAC resources accordingly
+            - strimzi-cluster-operator
+          verbs:
+            - get
+            - list
+            - watch
+            - delete
+            - patch
+            - update
+        serviceAccountName: strimzi-cluster-operator
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - "rbac.authorization.k8s.io"
+          resources:
+          # The cluster operator needs to create and manage cluster role bindings in the case of an install where a user
+          # has specified they want their cluster role bindings generated
+          - clusterrolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          # The cluster operator requires "get" permissions to view storage class details
+          # This is because only a persistent volume of a supported storage class type can be resized
+          - storageclasses
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          # The cluster operator requires "list" permissions to view all nodes in a cluster
+          # The listing is used to determine the node addresses when NodePort access is configured
+          # These addresses are then exposed in the custom resource states
+          # The Kafka Brokers require "get" permissions to view the node they are on
+          # This information is used to generate a Rack ID that is used for High Availability configurations
+          - nodes
+          verbs:
+          - get
+          - list
+        serviceAccountName: strimzi-cluster-operator
+      deployments:
+      - name: amq-streams-cluster-operator-v2.5.0-0
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: amq-streams-cluster-operator
+              strimzi.io/kind: cluster-operator
+          template:
+            metadata:
+              labels:
+                name: amq-streams-cluster-operator
+                strimzi.io/kind: cluster-operator
+                com.company: Red_Hat
+                rht.prod_name: Red_Hat_Application_Foundations
+                rht.prod_ver: 2023.Q3
+                rht.comp: AMQ_Streams
+                rht.comp_ver: "2.5"
+                rht.subcomp: cluster-operator
+                rht.subcomp_t: infrastructure
+            spec:
+              serviceAccountName: strimzi-cluster-operator
+              volumes:
+                - name: strimzi-tmp
+                  emptyDir:
+                    medium: Memory
+                - name: co-config-volume
+                  configMap:
+                    name: strimzi-cluster-operator
+              containers:
+                - name: strimzi-cluster-operator
+                  image: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+                  ports:
+                    - containerPort: 8080
+                      name: http
+                  args:
+                    - /opt/strimzi/bin/cluster_operator_run.sh
+                  volumeMounts:
+                    - name: strimzi-tmp
+                      mountPath: /tmp
+                    - name: co-config-volume
+                      mountPath: /opt/strimzi/custom-config/
+                  env:
+                    - name: STRIMZI_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.annotations['olm.targetNamespaces']
+                    - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+                      value: "120000"
+                    - name: STRIMZI_OPERATION_TIMEOUT_MS
+                      value: "300000"
+                    - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+                      value: registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+                      value: registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+                      value: registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_KAFKA_IMAGES
+                      value: |
+                        3.4.0=registry.redhat.io/amq-streams/kafka-34-rhel8@sha256:385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef
+                        3.5.0=registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_KAFKA_CONNECT_IMAGES
+                      value: |
+                        3.4.0=registry.redhat.io/amq-streams/kafka-34-rhel8@sha256:385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef
+                        3.5.0=registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+                      value: |
+                        3.4.0=registry.redhat.io/amq-streams/kafka-34-rhel8@sha256:385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef
+                        3.5.0=registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+                      value: |
+                        3.4.0=registry.redhat.io/amq-streams/kafka-34-rhel8@sha256:385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef
+                        3.5.0=registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+                    - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+                      value: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+                    - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+                      value: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+                    - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+                      value: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+                    - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+                      value: registry.redhat.io/amq-streams/bridge-rhel8@sha256:e534a7105a2eeb7c11f4d604987a70459f84561dfa9bcb59173630fc21b5c58c
+                    - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+                      value: |
+                        discovery.3scale.net=true
+                    - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+                      value: |
+                        discovery.3scale.net/scheme=http
+                        discovery.3scale.net/port=8080
+                        discovery.3scale.net/path=/
+                        discovery.3scale.net/description-path=/openapi
+                    - name: STRIMZI_DEFAULT_MAVEN_BUILDER
+                      value: registry.redhat.io/ubi8/openjdk-17@sha256:8796da64c626c5f63f31a4e3ac0ac3b179333a7c6d5472a195b9b3f61ccd1099
+                    - name: STRIMZI_OPERATOR_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: STRIMZI_FEATURE_GATES
+                      value: ""
+                    - name: STRIMZI_LEADER_ELECTION_ENABLED
+                      value: "true"
+                    - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+                      value: "strimzi-cluster-operator"
+                    - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: STRIMZI_LEADER_ELECTION_IDENTITY
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+                    - name: STRIMZI_CUSTOM_KAFKA_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-broker
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-connect
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-connect-build
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=zookeeper
+                        rht.subcomp_t=infrastructure
+                    - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=entity-operator
+                        rht.subcomp_t=infrastructure
+                    - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-mirror-maker2
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-mirror-maker
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=cruise-control
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-bridge
+                        rht.subcomp_t=application
+                    - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+                      value: |
+                        com.company=Red_Hat
+                        rht.prod_name=Red_Hat_Application_Foundations
+                        rht.prod_ver=2023.Q3
+                        rht.comp=AMQ_Streams
+                        rht.comp_ver=2.5
+                        rht.subcomp=kafka-exporter
+                        rht.subcomp_t=application
+                  livenessProbe:
+                    httpGet:
+                      path: /healthy
+                      port: http
+                    initialDelaySeconds: 10
+                    periodSeconds: 30
+                  readinessProbe:
+                    httpGet:
+                      path: /ready
+                      port: http
+                    initialDelaySeconds: 10
+                    periodSeconds: 30
+                  resources:
+                    limits:
+                      cpu: 1000m
+                      memory: 384Mi
+                    requests:
+                      cpu: 200m
+                      memory: 384Mi
+          strategy:
+            type: Recreate
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  relatedImages:
+    - name: strimzi-cluster-operator
+      image: registry.redhat.io/amq-streams/strimzi-rhel8-operator@sha256:3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4
+    - name: strimzi-kafka-340
+      image: registry.redhat.io/amq-streams/kafka-34-rhel8@sha256:385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef
+    - name: strimzi-kafka-350
+      image: registry.redhat.io/amq-streams/kafka-35-rhel8@sha256:9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b
+    - name: strimzi-bridge
+      image: registry.redhat.io/amq-streams/bridge-rhel8@sha256:e534a7105a2eeb7c11f4d604987a70459f84561dfa9bcb59173630fc21b5c58c
+    - name: strimzi-maven-builder
+      image: registry.redhat.io/ubi8/openjdk-17@sha256:8796da64c626c5f63f31a4e3ac0ac3b179333a7c6d5472a195b9b3f61ccd1099
+  keywords:
+    - kafka
+    - messaging
+    - kafka-connect
+    - kafka-streams
+    - data-streaming
+    - data-streams
+    - streaming
+    - streams
+  labels:
+    name: amq-streams-cluster-operator
+  links:
+    - name: Product Page
+      url: https://access.redhat.com/products/red-hat-amq
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/red_hat_amq_streams
+
+  maintainers:
+    - email: customerservice@redhat.com
+      name: Red Hat
+  maturity: stable
+  provider:
+    name: Red Hat
+  replaces: amqstreams.v2.4.0-0
+  selector:
+    matchLabels:
+      name: amq-streams-cluster-operator
+  version: 2.5.0-0

--- a/operator-metadata/automation/tests/resources/test.image.yaml
+++ b/operator-metadata/automation/tests/resources/test.image.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+
+name: amq-streams/strimzi-operator-bundle
+description: "AMQ Streams image containing the operator metadata"
+version: "2.5.0"
+from: scratch
+
+labels:
+  - name: "com.redhat.component"
+    value: "amqstreams-bundle-container"
+  - name: "io.k8s.description"
+    value: "Operator metadata"
+  - name: "io.k8s.display-name"
+    value: "AMQ Streams Operator metadata"
+  - name: "io.openshift.tags"
+    value: "messaging,amq,jboss"
+  - name: "operators.operatorframework.io.bundle.mediatype.v1"
+    value: "registry+v1"
+  - name: "operators.operatorframework.io.bundle.manifests.v1"
+    value: "manifests/"
+  - name: "operators.operatorframework.io.bundle.metadata.v1"
+    value: "metadata/"
+  - name: "operators.operatorframework.io.bundle.package.v1"
+    value: "amq-streams"
+  - name: "operators.operatorframework.io.bundle.channels.v1"
+    value: "stable,amq-streams-2.x,amq-streams-2.5.x"
+  - name: "operators.operatorframework.io.bundle.channel.default.v1"
+    value: "stable"
+  - name: "com.redhat.delivery.operator.bundle"
+    value: "true"
+  - name: "com.redhat.openshift.versions"
+    value: "v4.8"
+  - name: "maintainer"
+    value: "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
+
+artifacts:
+    - path: manifests
+      dest: /manifests/
+    - path: metadata
+      dest: /metadata/
+
+help:
+  add: true
+
+osbs:
+  configuration:
+    container_file: container.yaml
+    gating_file: gating.yaml
+  extra_dir: dist-git-files
+  repository:
+    name: containers/amqstreams-operator-prod-operator-metadata
+    branch: amqstreams-2.5-rhel-8

--- a/operator-metadata/automation/tests/test_bundle_automation.py
+++ b/operator-metadata/automation/tests/test_bundle_automation.py
@@ -1,0 +1,81 @@
+import os
+import unittest
+
+from automation.modules import constants
+from automation.modules.bundle_automation import BundleAutomation
+from automation.modules.file import File
+
+
+class TestBundleAutomation(unittest.TestCase):
+    RESOURCES_PATH = "resources/"
+    DESCRIPTOR_FILE_PATH = RESOURCES_PATH + "test.image.yaml"
+    CSV_FILE_PATH = RESOURCES_PATH + "test.bundle.clusterserviceversion.yaml"
+
+    def setUp(self):
+        build_info = [
+            "CONTAINER_BUILDS_BRIDGE_BUILD_INFO_JSON",
+            "CONTAINER_BUILDS_DRAIN_CLEANER_BUILD_INFO_JSON",
+            "CONTAINER_BUILDS_KAFKA_34_BUILD_INFO_JSON",
+            "CONTAINER_BUILDS_KAFKA_35_BUILD_INFO_JSON",
+            "CONTAINER_BUILDS_OPERATOR_BUILD_INFO_JSON"
+        ]
+
+        for component in build_info:
+            with open(self.RESOURCES_PATH + component, 'r') as file:
+                data = file.read().rstrip()
+                os.environ[component] = data
+
+        self.descriptor = File(TestBundleAutomation.DESCRIPTOR_FILE_PATH)
+        self.csv = File(TestBundleAutomation.CSV_FILE_PATH)
+
+    def test_collect_component_build_info(self):
+        build_info = BundleAutomation.collect_component_build_info()
+        self.assertEqual(len(build_info), 5)
+
+    def test_update_csv_file(self):
+        automation = BundleAutomation()
+
+        csv_file = File(self.CSV_FILE_PATH)
+        bundle_versions = ["2.5.0-0", "2.5.0-1"]
+
+        operator_sha = "test0"
+        kafka_35_sha = "test1"
+        kafka_34_sha = "test2"
+        bridge_sha = "test3"
+        maven_builder_sha = "test4"
+
+        sha_dict = {
+            "3eec64199147feed58986202781dec4bf3efa43e7585aa37012c265af16a95c4": operator_sha,
+            "9f43707f3b6b893177cb50fe77b92a742c90b48f39c77d4a8f4ebe340634a46b": kafka_35_sha,
+            "385d66c176995111ae06a875e6849dcb3c70db68a305bcb029759208d0c7c9ef": kafka_34_sha,
+            "e534a7105a2eeb7c11f4d604987a70459f84561dfa9bcb59173630fc21b5c58c": bridge_sha,
+            "8796da64c626c5f63f31a4e3ac0ac3b179333a7c6d5472a195b9b3f61ccd1099": maven_builder_sha
+                   }
+
+        # Update CSV with new versions numbers and SHA hashes
+        data = automation.update_csv_data(csv_file.data, bundle_versions, sha_dict)
+
+        # Check replaces field
+        self.assertEqual(bundle_versions[constants.OLD_BUNDLE_VERSION_INDEX], automation.get_replace_version(data))
+
+        # Check version fields
+        bundle_version = bundle_versions[constants.NEW_BUNDLE_VERSION_INDEX]
+        self.assertEqual(bundle_version, automation.get_bundle_version(data))
+        self.assertEqual(bundle_version, automation.extract_version(automation.get_bundle_name(data)))
+        self.assertEqual(bundle_version, automation.extract_version(automation.get_bundle_deployment_name(data)))
+
+        # Check skipRange field
+        bundle_version_start = automation.set_build_version(automation.decrement_minor_version(bundle_version), 0)
+        self.assertEqual(bundle_version_start, automation.get_skip_range(data).split("<")[0].split("=")[-1].strip())
+        self.assertEqual(bundle_version, automation.get_skip_range(data).split("<")[-1])
+
+        # Check SHA replacement
+        self.assertEqual(6, data.count(operator_sha))
+        self.assertEqual(8, data.count(kafka_35_sha))
+        self.assertEqual(5, data.count(kafka_34_sha))
+        self.assertEqual(2, data.count(bridge_sha))
+        self.assertEqual(2, data.count(maven_builder_sha))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -46,7 +46,7 @@ osbs:
   configuration:
     container_file: container.yaml
     gating_file: gating.yaml
-  extra_dir: dist-git-files
+  extra_dir: automation
   repository:
     name: containers/amqstreams-operator-prod-operator-metadata
-    branch: amqstreams-2.5-rhel-8
+    branch: master


### PR DESCRIPTION
Up until now, the automation scripts for updating our bundle metadata have lived in internal git repos making them difficult to update and collaborate on. Centralizing the scripts here will make them easier to work on and sync across internal git repos that need the scripts.

These automation scripts are automatically synced with internal git repos and executed as part of the CPaaS container build pipeline:

```
(1) CPaaS builds container images
(2) CPaaS executes these automation scripts, updating bundle metadata 
(3) CPaaS builds bundle image using updated bundle metadata 
```
