### PR TITLE
Update CRDs for AMQ Streams 2.6.0 release

### DIFF
--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -168,6 +168,9 @@ spec:
                             httpRetryPauseMs:
                               type: integer
                               description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                            includeAcceptHeader:
+                              type: boolean
+                              description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                             introspectionEndpointUri:
                               type: string
                               description: URI of the token introspection endpoint which can be used to validate opaque non-JWT tokens.
@@ -465,7 +468,7 @@ spec:
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers,node.id, process.roles, controller. (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size,ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas,controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers,node.id, process.roles, controller., metadata.log.dir (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size,ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation,cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms,cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms,cruise.control.metrics.topic.min.insync.replicas,controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
                   storage:
                     type: object
                     properties:
@@ -610,6 +613,9 @@ spec:
                         type: integer
                         minimum: 0
                         description: "The maximum number of retries to attempt if an initial HTTP request fails. If not set, the default is to not attempt any retries."
+                      includeAcceptHeader:
+                        type: boolean
+                        description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                       initialCacheCapacity:
                         type: integer
                         description: Initial capacity of the local cache used by the authorizer to avoid querying the Open Policy Agent for every request Defaults to `5000`.
@@ -653,7 +659,7 @@ spec:
                         - opa
                         - keycloak
                         - custom
-                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
+                        description: "Authorization type. Currently, the supported types are `simple`, `keycloak`, `opa` and `custom`. `simple` authorization type uses Kafka's built-in authorizer for authorization. `keycloak` authorization type uses Keycloak Authorization Services for authorization. `opa` authorization type uses Open Policy Agent based authorization.`custom` authorization type uses user-provided implementation for authorization."
                       url:
                         type: string
                         example: http://opa:8181/v1/data/kafka/authz/allow
@@ -6268,7 +6274,7 @@ spec:
                   properties:
                     type:
                       type: string
-                      description: "*The `type` property has been deprecated, and should now be configured using `name`.* The name of the listener."
+                      description: The name of the listener.
                     name:
                       type: string
                       description: The name of the listener.
@@ -6305,4 +6311,10 @@ spec:
               clusterId:
                 type: string
                 description: Kafka cluster Id.
+              operatorLastSuccessfulVersion:
+                type: string
+                description: The version of the Strimzi Cluster Operator which performed the last successful reconciliation.
+              kafkaVersion:
+                type: string
+                description: The version of Kafka currently deployed in the cluster.
             description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."

--- a/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -146,6 +146,9 @@ spec:
                   httpRetryPauseMs:
                     type: integer
                     description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                  includeAcceptHeader:
+                    type: boolean
+                    description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                   maxTokenExpirySeconds:
                     type: integer
                     description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
@@ -380,7 +383,7 @@ spec:
                     enum:
                     - jaeger
                     - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                    description: "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored."
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.

--- a/install/cluster-operator/044-Crd-kafkauser.yaml
+++ b/install/cluster-operator/044-Crd-kafkauser.yaml
@@ -161,7 +161,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -382,7 +382,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -603,7 +603,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type

--- a/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
+++ b/install/cluster-operator/045-Crd-kafkamirrormaker.yaml
@@ -151,6 +151,9 @@ spec:
                       httpRetryPauseMs:
                         type: integer
                         description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                      includeAcceptHeader:
+                        type: boolean
+                        description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                       maxTokenExpirySeconds:
                         type: integer
                         description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
@@ -325,6 +328,9 @@ spec:
                       httpRetryPauseMs:
                         type: integer
                         description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                      includeAcceptHeader:
+                        type: boolean
+                        description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                       maxTokenExpirySeconds:
                         type: integer
                         description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
@@ -537,7 +543,7 @@ spec:
                     enum:
                     - jaeger
                     - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                    description: "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored."
                 required:
                 - type
                 description: The configuration of tracing in Kafka MirrorMaker.

--- a/install/cluster-operator/046-Crd-kafkabridge.yaml
+++ b/install/cluster-operator/046-Crd-kafkabridge.yaml
@@ -149,6 +149,9 @@ spec:
                   httpRetryPauseMs:
                     type: integer
                     description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                  includeAcceptHeader:
+                    type: boolean
+                    description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                   maxTokenExpirySeconds:
                     type: integer
                     description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
@@ -1128,7 +1131,7 @@ spec:
                     enum:
                     - jaeger
                     - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                    description: "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored."
                 required:
                 - type
                 description: The configuration of tracing in Kafka Bridge.

--- a/install/cluster-operator/047-Crd-kafkaconnector.yaml
+++ b/install/cluster-operator/047-Crd-kafkaconnector.yaml
@@ -65,6 +65,9 @@ spec:
                   enabled:
                     type: boolean
                     description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                  maxRestarts:
+                    type: integer
+                    description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                 description: Automatic restart of connector and tasks configuration.
               config:
                 x-kubernetes-preserve-unknown-fields: true
@@ -73,6 +76,13 @@ spec:
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.
+              state:
+                type: string
+                enum:
+                - paused
+                - stopped
+                - running
+                description: The state the connector should be in. Defaults to running.
             description: The specification of the Kafka Connector.
           status:
             type: object

--- a/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -56,7 +56,7 @@ spec:
                 description: The docker image for the pods.
               connectCluster:
                 type: string
-                description: The cluster alias used for Kafka Connect. The alias must match a cluster in the list at `spec.clusters`.
+                description: The cluster alias used for Kafka Connect. The value must match the alias of the *target* Kafka cluster as specified in the `spec.clusters` configuration. The target Kafka cluster is used by the underlying Kafka Connect framework for its internal topics.
               clusters:
                 type: array
                 items:
@@ -158,6 +158,9 @@ spec:
                         httpRetryPauseMs:
                           type: integer
                           description: "The pause to take before retrying a failed HTTP request. If not set, the default is to not pause at all but to immediately repeat a request."
+                        includeAcceptHeader:
+                          type: boolean
+                          description: Whether the Accept header should be set in requests to the authorization servers. The default value is `true`.
                         maxTokenExpirySeconds:
                           type: integer
                           description: Set or limit time-to-live of the access tokens to the specified number of seconds. This should be set if the authorization server returns opaque tokens.
@@ -262,10 +265,20 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 source connector.
                     heartbeatConnector:
                       type: object
@@ -284,10 +297,20 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                     checkpointConnector:
                       type: object
@@ -306,10 +329,20 @@ spec:
                             enabled:
                               type: boolean
                               description: Whether automatic restart for failed connectors and tasks should be enabled or disabled.
+                            maxRestarts:
+                              type: integer
+                              description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
                         pause:
                           type: boolean
                           description: Whether the connector should be paused. Defaults to false.
+                        state:
+                          type: string
+                          enum:
+                          - paused
+                          - stopped
+                          - running
+                          description: The state the connector should be in. Defaults to running.
                       description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                     topicsPattern:
                       type: string
@@ -495,7 +528,7 @@ spec:
                     enum:
                     - jaeger
                     - opentelemetry
-                    description: Type of the tracing used. Currently the only supported types are `jaeger` for OpenTracing (Jaeger) tracing and `opentelemetry` for OpenTelemetry tracing. The OpenTracing (Jaeger) tracing is deprecated.
+                    description: "Type of the tracing used. Currently the only supported type is `opentelemetry` for OpenTelemetry tracing. As of Strimzi 0.37.0, `jaeger` type is not supported anymore and this option is ignored."
                 required:
                 - type
                 description: The configuration of tracing in Kafka Connect.

--- a/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -34,10 +34,6 @@ spec:
       description: The desired number of replicas
       jsonPath: .spec.replicas
       type: integer
-    - name: Ready
-      description: The state of the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
     schema:
       openAPIV3Schema:
         type: object

--- a/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-ConfigMap-strimzi-cluster-operator.yaml
@@ -29,7 +29,3 @@ data:
     # Keeps separate level for Netty logging -> to not be changed by the root logger
     logger.netty.name = io.netty
     logger.netty.level = INFO
-
-    # Keeps separate log level for OkHttp client
-    logger.okhttp3.name = okhttp3
-    logger.okhttp3.level = INFO

--- a/install/drain-cleaner/openshift/021-Role.yaml
+++ b/install/drain-cleaner/openshift/021-Role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+rules:
+  # When certificate reloading is enabled, Drain Cleaner will delete itself to reload the certificates. Therefore it
+  # needs the right to delete the pods in its own namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  # When certificate reloading is enabled, Strimzi needs to be able to get, list and watch the Secret with the
+  # certificate to detect any changes to it. The RBAC allows it to watch only one Secret with given name. If your
+  # certificate Secret has a custom name, you need to modify this Role accordingly.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+    resourceNames:
+      - strimzi-drain-cleaner

--- a/install/drain-cleaner/openshift/031-RoleBinding.yaml
+++ b/install/drain-cleaner/openshift/031-RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: strimzi-drain-cleaner
+  labels:
+    app: strimzi-drain-cleaner
+  namespace: strimzi-drain-cleaner
+subjects:
+  - kind: ServiceAccount
+    name: strimzi-drain-cleaner
+    namespace: strimzi-drain-cleaner
+roleRef:
+  kind: Role
+  name: strimzi-drain-cleaner
+  apiGroup: rbac.authorization.k8s.io

--- a/install/drain-cleaner/openshift/060-Deployment.yaml
+++ b/install/drain-cleaner/openshift/060-Deployment.yaml
@@ -36,10 +36,27 @@ spec:
             - "-Dquarkus.http.host=0.0.0.0"
             - "--kafka"
             - "--zookeeper"
+          env:
+            - name: STRIMZI_DRAIN_KAFKA
+              value: "true"
+            - name: STRIMZI_DRAIN_ZOOKEEPER
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_ENABLED
+              value: "true"
+            - name: STRIMZI_CERTIFICATE_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_CERTIFICATE_WATCH_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: webhook-certificates
               mountPath: "/etc/webhook-certificates"
               readOnly: true
+            - name: tmp-dir
+              emptyDir: {}
           livenessProbe:
             httpGet:
               path: /health

--- a/install/user-operator/04-Crd-kafkauser.yaml
+++ b/install/user-operator/04-Crd-kafkauser.yaml
@@ -161,7 +161,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -382,7 +382,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type
@@ -603,7 +603,7 @@ spec:
                     type: string
                     enum:
                     - simple
-                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses Kafka's `kafka.security.authorizer.AclAuthorizer` class for authorization.
+                    description: Authorization type. Currently the only supported type is `simple`. `simple` authorization type uses the Kafka Admin API for managing the ACL rules.
                 required:
                 - acls
                 - type


### PR DESCRIPTION
We missed backporting the CRDs when doing the original update to our install files. 

This PR adds the missing updates
