### PR TITLE
enabling gating for x86

### DIFF
--- a/proxy/gating.yaml
+++ b/proxy/gating.yaml
@@ -9,7 +9,7 @@ decision_contexts:
 rules:
   # Rules are in format <namespace>.<type>.<category>
   # TODO - need proxy test suite
-  #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
+  - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}
   #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.aarch64}

--- a/proxy/gating.yaml
+++ b/proxy/gating.yaml
@@ -8,7 +8,6 @@ decision_contexts:
   - cvp_default
 rules:
   # Rules are in format <namespace>.<type>.<category>
-  # TODO - need proxy test suite
   - !PassingTestCaseRule {test_case_name: amq-streams.systemtest.x86_64}
   #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.ppc64le}
   #- !PassingTestCaseRule {test_case_name: amq-streams.systemtest.s390x}


### PR DESCRIPTION
We need to enable the gating for Proxy in x86, that is the only architecture currently supported.

That will apply some kind of requirements before we can proceed with the release.