### PR TITLE
Switch to contentset in sync with the base image.

### DIFF
--- a/proxy/image.yaml
+++ b/proxy/image.yaml
@@ -33,8 +33,8 @@ packages:
       # Required for tini
       - amq-streams-2-for-rhel-8-rpms
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
     - hostname


### PR DESCRIPTION
As part of the FIPS work, the contentset used need to be in sync with the base image.