### PR TITLE
Update example to refer to published downstream proxy image

### DIFF
--- a/examples/proxy/record-encryption/base/proxy/proxy-deployment.yaml
+++ b/examples/proxy/record-encryption/base/proxy/proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: proxy
-        image: quay.io/kroxylicious/kroxylicious:0.5.0-SNAPSHOT
+        image: registry.redhat.io/amq-streams/proxy-rhel8:2.7
         imagePullPolicy: Always
         args: ["--config", "/opt/proxy/config/config.yaml"]
         ports:

--- a/examples/proxy/record-encryption/cluster-ip/README.md
+++ b/examples/proxy/record-encryption/cluster-ip/README.md
@@ -28,19 +28,19 @@ Cluster-IP.
    ```
 2. Create a topic `trades` on the cluster, via the proxy:
    ```
-   oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-36-rhel8:2.6.0-4 --rm=true --restart=Never -- kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic trades
+   oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel8:2.7.0 --rm=true --restart=Never -- kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic trades
    ```
 3. Produce some messages to the topic:
    ```
-   echo 'IBM:100\nAPPLE:99' | oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-36-rhel8:2.6.0-4 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic trades   
+   echo 'IBM:100\nAPPLE:99' | oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel8:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic trades
    ```
 4. Consume messages *direct* from the Kafka Cluster, showing that they are encrypted.
    ```
-    oc run -n kafka cluster-consumer -qi --image=registry.redhat.io/amq-streams/kafka-36-rhel8:2.6.0-4 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic trades --from-beginning --timeout-ms 10000
+    oc run -n kafka cluster-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel8:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic trades --from-beginning --timeout-ms 10000
    ```
 5. Consume messages from the *proxy* showing they get decrypted automatically.   
    ```
-    oc run -n proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-36-rhel8:2.6.0-4 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic trades --from-beginning --timeout-ms 10000
+    oc run -n proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel8:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic trades --from-beginning --timeout-ms 10000
    ```   
 
 # Cleaning up

--- a/examples/proxy/record-encryption/load-balancer/README.md
+++ b/examples/proxy/record-encryption/load-balancer/README.md
@@ -51,7 +51,7 @@ Service.
    ```
 5. Consume messages direct from the Kafka Cluster, showing that they are encrypted:
    ```
-    oc run -n kafka cluster-consumer -qi --image=registry.redhat.io/amq-streams/kafka-36-rhel8:2.6.0-4 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic trades --from-beginning --timeout-ms 10000
+    oc run -n kafka cluster-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel8:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic trades --from-beginning --timeout-ms 10000
    ```
 6. Consume messages from the proxy showing they are decrypted:
    ```


### PR DESCRIPTION
The example content needs to refer to the downstream proxy image, rather than the upstream one.
As per https://issues.redhat.com/browse/SPMM-16330, we will refer to it by floating tag (x.y), in order to obviate the need to refresh the example content if the AMQ Streams is re-released.

https://errata.devel.redhat.com/package/show/amqstreams-proxy-container
https://errata.devel.redhat.com/package/show/amqstreams-kafka-37-container

#460 