### PR TITLE
add tzdata to kafka image yamls

### DIFF
--- a/kafka/kafka-3.5.0/image.yaml
+++ b/kafka/kafka-3.5.0/image.yaml
@@ -63,6 +63,7 @@ packages:
     - bind-utils
     - tini
     - lsof
+    - tzdata
 
 run:
   user: 1001

--- a/kafka/kafka-3.6.0/image.yaml
+++ b/kafka/kafka-3.6.0/image.yaml
@@ -63,6 +63,7 @@ packages:
     - bind-utils
     - tini
     - lsof
+    - tzdata
 
 run:
   user: 1001


### PR DESCRIPTION
- This is needed for Pipeline builds to pass. tzdata is an added patch.