### PR TITLE
(Experiment) Suppress installation of weak dependencies

### DIFF
--- a/proxy/image.yaml
+++ b/proxy/image.yaml
@@ -28,6 +28,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for tini


### PR DESCRIPTION
Trying to influence Cekit to prevent dnf from install weak-dependencies.

why: the RPM transaction was installing things like dracut, which is pulling in grub!  We don't want these in AMQ Streams images!

https://docs.cekit.io/en/latest/descriptor/image.html#package-manager-flags
