### PR TITLE
Refactor content sets for rhel8-els image

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -33,26 +33,26 @@ packages:
       # Required for tini
       - amq-streams-2-for-rhel-8-rpms
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
     ppc64le:
       # Required for tini
       - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
-      - rhel-8-for-ppc64le-baseos-rpms
-      - rhel-8-for-ppc64le-appstream-rpms
+      - rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
     s390x:
       # Required for tini
       - amq-streams-2-for-rhel-8-s390x-rpms
       # Required for base image
-      - rhel-8-for-s390x-baseos-rpms
-      - rhel-8-for-s390x-appstream-rpms  
+      - rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     aarch64:
       # Required for tini
       - amq-streams-2-for-rhel-8-aarch64-rpms
       # Required for base image
-      - rhel-8-for-aarch64-baseos-rpms
-      - rhel-8-for-aarch64-appstream-rpms
+      - rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
     - openssl

--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -28,6 +28,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for tini

--- a/drain-cleaner/image.yaml
+++ b/drain-cleaner/image.yaml
@@ -28,6 +28,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for base image

--- a/drain-cleaner/image.yaml
+++ b/drain-cleaner/image.yaml
@@ -31,20 +31,20 @@ packages:
   content_sets:
     x86_64:
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
     ppc64le:
       # Required for base image
-      - rhel-8-for-ppc64le-baseos-rpms
-      - rhel-8-for-ppc64le-appstream-rpms
+      - rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
     s390x:
       # Required for base image
-      - rhel-8-for-s390x-baseos-rpms
-      - rhel-8-for-s390x-appstream-rpms  
+      - rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     aarch64:
       # Required for base image
-      - rhel-8-for-aarch64-baseos-rpms
-      - rhel-8-for-aarch64-appstream-rpms
+      - rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
 

--- a/kafka/kafka-3.6.0/image.yaml
+++ b/kafka/kafka-3.6.0/image.yaml
@@ -27,6 +27,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for tini and kafka exporter

--- a/kafka/kafka-3.6.0/image.yaml
+++ b/kafka/kafka-3.6.0/image.yaml
@@ -32,26 +32,26 @@ packages:
       # Required for tini and kafka exporter
       - amq-streams-2-for-rhel-8-rpms
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
     ppc64le:
       # Required for tini and kafka exporter
       - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
-      - rhel-8-for-ppc64le-baseos-rpms
-      - rhel-8-for-ppc64le-appstream-rpms
+      - rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
     s390x:
       # Required for tini and kafka_exporter
       - amq-streams-2-for-rhel-8-s390x-rpms
       # Required for base image
-      - rhel-8-for-s390x-baseos-rpms
-      - rhel-8-for-s390x-appstream-rpms
+      - rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     aarch64:
       # Required for tini
       - amq-streams-2-for-rhel-8-aarch64-rpms
       # Required for base image
-      - rhel-8-for-aarch64-baseos-rpms
-      - rhel-8-for-aarch64-appstream-rpms
+      - rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
     - gettext

--- a/kafka/kafka-3.7.0/image.yaml
+++ b/kafka/kafka-3.7.0/image.yaml
@@ -27,6 +27,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for tini and kafka exporter

--- a/kafka/kafka-3.7.0/image.yaml
+++ b/kafka/kafka-3.7.0/image.yaml
@@ -32,26 +32,26 @@ packages:
       # Required for tini and kafka exporter
       - amq-streams-2-for-rhel-8-rpms
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
     ppc64le:
       # Required for tini and kafka exporter
       - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
-      - rhel-8-for-ppc64le-baseos-rpms
-      - rhel-8-for-ppc64le-appstream-rpms
+      - rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
     s390x:
       # Required for tini and kafka_exporter
       - amq-streams-2-for-rhel-8-s390x-rpms
       # Required for base image
-      - rhel-8-for-s390x-baseos-rpms
-      - rhel-8-for-s390x-appstream-rpms 
+      - rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     aarch64:
       # Required for tini
       - amq-streams-2-for-rhel-8-aarch64-rpms
       # Required for base image
-      - rhel-8-for-aarch64-baseos-rpms
-      - rhel-8-for-aarch64-appstream-rpms
+      - rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
     - gettext

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -28,6 +28,7 @@ modules:
 
 packages:
   manager: dnf
+  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
   content_sets:
     x86_64:
       # Required for tini

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -33,26 +33,26 @@ packages:
       # Required for tini
       - amq-streams-2-for-rhel-8-rpms
       # Required for base image
-      - rhel-8-for-x86_64-baseos-rpms
-      - rhel-8-for-x86_64-appstream-rpms
+      - rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
     ppc64le:
       # Required for tini
       - amq-streams-2-for-rhel-8-ppc64le-rpms
       # Required for base image
-      - rhel-8-for-ppc64le-baseos-rpms
-      - rhel-8-for-ppc64le-appstream-rpms
+      - rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
     s390x:
       # Required for tini
       - amq-streams-2-for-rhel-8-s390x-rpms
       # Required for base image
-      - rhel-8-for-s390x-baseos-rpms
-      - rhel-8-for-s390x-appstream-rpms 
+      - rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     aarch64:
       # Required for tini
       - amq-streams-2-for-rhel-8-aarch64-rpms
       # Required for base image
-      - rhel-8-for-aarch64-baseos-rpms
-      - rhel-8-for-aarch64-appstream-rpms
+      - rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      - rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
   install:
     - java-17-openjdk-devel
     - openssl


### PR DESCRIPTION
Having changed to a new base image, the following addition is needed for the rpm definition: `-eus-rpms__8_DOT_6`