### PR TITLE
Remove experiment that tied container to specific nss version

### DIFF
--- a/proxy/image.yaml
+++ b/proxy/image.yaml
@@ -42,7 +42,6 @@ packages:
     - tini
     - net-tools
     - lsof
-    - nss-3.67.0-7.el8_5
   remove:
     - vim-minimal
     - subscription-manager


### PR DESCRIPTION
This is no longer required as we are switching to RHEL-9.