### PR TITLE
Bug fix to example content

### DIFF
--- a/examples/proxy/record-encryption/cluster-ip/README.md
+++ b/examples/proxy/record-encryption/cluster-ip/README.md
@@ -28,7 +28,7 @@ Cluster-IP.
    ```
 2. Create a topic `trades` on the cluster, via the proxy:
    ```
-   oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic trades
+   oc run -n proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic trades
    ```
 3. Produce some messages to the topic:
    ```


### PR DESCRIPTION
The container command line for creating the topic is incorrect.

It looks like the documentation has the command line correct

https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.7/html/using_the_streams_for_apache_kafka_proxy/proc-deploying-proxy-str#proc-deploying-proxy-str
