### PR TITLE
ENTMQST-6192: use maven-openjdk17

### DIFF
--- a/maven-builder/image.yaml
+++ b/maven-builder/image.yaml
@@ -56,7 +56,7 @@ packages:
       - rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_2
   install:
     - java-17-openjdk-devel
-    - maven
+    - maven-openjdk17
     - openssl
     - nmap-ncat
     - hostname


### PR DESCRIPTION
use maven-openjdk17 rather than `maven` to avoid a OpenJDK 11 being installed in the image.