### PR TITLE
ENTMQSTPR-47: Record validation example with Red Hat build of Apicurio Registry

### DIFF
--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -2,6 +2,6 @@
 
 In this directory you'll find examples that let you try out Streams for Apache Kafka Proxy.
 
-* [Record Encryption](./record-encryption)
+* [Record Encryption](./record-encryption) - An encryption-at-Rest solution for Apache Kafka(tm) which is transparent to both clients and brokers.
 * [Record Validation](./record-validation)
 

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -1,7 +1,6 @@
 # Streams for Apache Kafka Proxy Examples
 
 In this directory you'll find examples that let you try out Streams for Apache Kafka Proxy.
-At present, one use-case is ready, which is Record Encryption.  Additional use-cases will be introduced later.
 
 * [Record Encryption](./record-encryption)
 * [Record Validation](./record-validation)

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -4,4 +4,5 @@ In this directory you'll find examples that let you try out Streams for Apache K
 At present, one use-case is ready, which is Record Encryption.  Additional use-cases will be introduced later.
 
 * [Record Encryption](./record-encryption)
+* [Record Validation](./record-validation)
 

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -2,6 +2,6 @@
 
 In this directory you'll find examples that let you try out Streams for Apache Kafka Proxy.
 
-* [Record Encryption](./record-encryption) - An encryption-at-Rest solution for Apache Kafka(tm) which is transparent to both clients and brokers.
-* [Record Validation](./record-validation)
+* [Record Encryption](./record-encryption) - Encryption-at-Rest solution for Apache Kafka(tm) which is transparent to both clients and brokers.
+* [Record Validation](./record-validation) - Ensures records produced to a kafka topic conform to an expected schema.
 

--- a/examples/proxy/record-validation/README.md
+++ b/examples/proxy/record-validation/README.md
@@ -2,7 +2,7 @@
 
 The Record Validation filter ensures that all records produced to a kafka topic conform to an expected schema.
 Records that don't conform to the expected schema will not be sent to the broker. Instead, the producer will
-receive an error response.  Record Validation filter currently support JSON format records.  It enforces JSON
+receive an error response. Record Validation filter currently support JSON format records.  It enforces JSON
 schemas.
 
 To use the Record Validation filter, you must have a JSON schema defined for records published to the topic.

--- a/examples/proxy/record-validation/README.md
+++ b/examples/proxy/record-validation/README.md
@@ -6,7 +6,7 @@ receive an error response. Record Validation filter currently support JSON forma
 schemas.
 
 To use the Record Validation filter, you must have a JSON schema defined for records published to the topic.
-The JSON schema need to be stored in an [Apicurio Registry](https://docs.redhat.com/en/documentation/red_hat_build_of_apicurio_registry/).
+The JSON schema must be stored in [Apicurio Registry](https://docs.redhat.com/en/documentation/red_hat_build_of_apicurio_registry/).
 
 In this directory, you'll find examples that help you deploy Streams for Apache Kafka with the Record Validation Filter
 to your OpenShift Cluster so that you may try out the feature together with you own application.

--- a/examples/proxy/record-validation/README.md
+++ b/examples/proxy/record-validation/README.md
@@ -1,0 +1,17 @@
+# Streams for Apache Kafka Proxy Record Validation Filter Examples
+
+The Record Validation filter ensures that all records produced to a kafka topic conform to an expected schema.
+Records that don't conform to the expected schema will not be sent to the broker. Instead, the producer will
+receive an error response.  Record Validation filter currently support JSON format records.  It enforces JSON
+schemas.
+
+To use the Record Validation filter, you must have a JSON schema defined for records published to the topic.
+The JSON schema need to be stored in an [Apicurio Registry](https://docs.redhat.com/en/documentation/red_hat_build_of_apicurio_registry/).
+
+In this directory, you'll find examples that help you deploy Streams for Apache Kafka with the Record Validation Filter
+to your OpenShift Cluster so that you may try out the feature together with you own application.
+The example provides a development instance of Apicurio Registry.
+
+* [Cluster IP](./cluster-ip)
+* [External Load Balancer](./load-balancer)
+

--- a/examples/proxy/record-validation/base/kafka/kafka-namespace.yaml
+++ b/examples/proxy/record-validation/base/kafka/kafka-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka

--- a/examples/proxy/record-validation/base/kafka/kafka-persistent.yaml
+++ b/examples/proxy/record-validation/base/kafka/kafka-persistent.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: kafka
+spec:
+  kafka:
+    version: 3.7.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.6"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 10Gi
+      deleteClaim: false

--- a/examples/proxy/record-validation/base/kafka/kafka-persistent.yaml
+++ b/examples/proxy/record-validation/base/kafka/kafka-persistent.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kafka
 spec:
   kafka:
-    version: 3.7.0
     replicas: 1
     listeners:
       - name: plain
@@ -19,7 +18,6 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.6"
     storage:
       type: jbod
       volumes:

--- a/examples/proxy/record-validation/base/kafka/kustomization.yaml
+++ b/examples/proxy/record-validation/base/kafka/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka
+
+resources:
+- kafka-namespace.yaml
+- kafka-persistent.yaml
+

--- a/examples/proxy/record-validation/base/kustomization.yaml
+++ b/examples/proxy/record-validation/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- kafka
+- schema-registry
+- proxy
+

--- a/examples/proxy/record-validation/base/proxy/kustomization.yaml
+++ b/examples/proxy/record-validation/base/proxy/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka-proxy
+
+resources:
+- proxy-namespace.yaml
+- proxy-deployment.yaml
+- proxy-pod-monitor.yaml
+

--- a/examples/proxy/record-validation/base/proxy/proxy-deployment.yaml
+++ b/examples/proxy/record-validation/base/proxy/proxy-deployment.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy
+  labels:
+    app: proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy
+  template:
+    metadata:
+      labels:
+        app: proxy
+    spec:
+      containers:
+      - name: proxy
+        image: registry.redhat.io/amq-streams/proxy-rhel9:2.7
+        imagePullPolicy: Always
+        args: ["--config", "/opt/proxy/config/config.yaml"]
+        ports:
+        - name: metrics
+          containerPort: 9190
+        - containerPort: 9092
+        - containerPort: 19092
+        - containerPort: 19093
+        - containerPort: 19094
+        volumeMounts:
+        - name: config-volume
+          mountPath: /opt/proxy/config/config.yaml
+          subPath: config.yaml
+      volumes:
+      - name: config-volume
+        configMap:
+          name: proxy-config

--- a/examples/proxy/record-validation/base/proxy/proxy-namespace.yaml
+++ b/examples/proxy/record-validation/base/proxy/proxy-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: proxy

--- a/examples/proxy/record-validation/base/proxy/proxy-namespace.yaml
+++ b/examples/proxy/record-validation/base/proxy/proxy-namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: proxy
+  name: kafka-proxy

--- a/examples/proxy/record-validation/base/proxy/proxy-pod-monitor.yaml
+++ b/examples/proxy/record-validation/base/proxy/proxy-pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: proxy
+  labels:
+    app: proxy
+spec:
+  selector:
+    matchLabels:
+      app: proxy
+  namespaceSelector:
+    matchNames:
+      - proxy
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics

--- a/examples/proxy/record-validation/base/schema-registry/kustomization.yaml
+++ b/examples/proxy/record-validation/base/schema-registry/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: schema-registry
+
+resources:
+- schema-registry-namespace.yaml
+- schema-registry-registry.yaml
+

--- a/examples/proxy/record-validation/base/schema-registry/schema-registry-namespace.yaml
+++ b/examples/proxy/record-validation/base/schema-registry/schema-registry-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: proxy

--- a/examples/proxy/record-validation/base/schema-registry/schema-registry-registry.yaml
+++ b/examples/proxy/record-validation/base/schema-registry/schema-registry-registry.yaml
@@ -1,0 +1,10 @@
+kind: ApicurioRegistry
+apiVersion: registry.apicur.io/v1
+metadata:
+  name: registry
+spec:
+  configuration:
+    kafkasql:
+      bootstrapServers: 'my-cluster-kafka-bootstrap.kafka.svc:9092'
+    persistence: kafkasql
+    registryLogLevel: DEBUG

--- a/examples/proxy/record-validation/base/schema-registry/schema-registry-registry.yaml
+++ b/examples/proxy/record-validation/base/schema-registry/schema-registry-registry.yaml
@@ -7,4 +7,4 @@ spec:
     kafkasql:
       bootstrapServers: 'my-cluster-kafka-bootstrap.kafka.svc:9092'
     persistence: kafkasql
-    registryLogLevel: DEBUG
+    # registryLogLevel: DEBUG

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -1,0 +1,69 @@
+# Streams for Apache Kafka Proxy Record Validation, exposed using Cluster-IP
+
+In this example, an instance of Apache Kafka is deployed using Streams for Apache Kafka.  Apicurio
+Registry is deployed to the cluster too.
+
+The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
+any records sent to a topic called `people` adhere to a `person` schema.
+
+Finally, kafka command line tools are used to send valid and invalid record to the `people` topic
+so that the effects of the validation can be observed.
+
+# Prerequisites
+
+* Administrative access to the OpenShift Cluster being used to evaluate Streams for Apache Kafka Proxy
+* Streams for Apache Kafka Operator (installed cluster wide)
+* Red Hat build of Apicurio Registry Operator (installed cluster wide)
+* OpenShift CLI (oc)
+* cURL
+
+# Deploying the Example
+
+1. Deploy the Example:
+   ```sh
+   oc apply -k cluster-ip
+   oc wait deployment/proxy --for=condition=Available=True --timeout=300s -n kafka-proxy
+   ```
+
+2. Create the example schema in the registry:
+
+   ```sh
+   REGISTRY_URL=http://$(oc get apicurioregistries.registry.apicur.io -n schema-registry registry --template='{{.status.info.host}}')
+   curl -X POST ${REGISTRY_URL}/apis/registry/v2/groups/default/artifacts -H "Content-Type: application/json; artifactType=JSON" -H "X-Registry-ArtifactId: Person" --data @schemas/person.schema.json
+   ```
+
+# Try out the example
+
+1. Create a topic `people` on the cluster, via the proxy:
+   ```sh
+   oc run -n kafka-proxy -qi create-topic --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic people
+   ```
+2. Produce a record to the topic with a record value that matches the schema.
+   ```sh
+   cat record-examples/valid-person.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
+   ```
+3. Consume messages showing the record reached the broker.
+   ```sh
+    oc run -n kafka-proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic people --from-beginning --timeout-ms 10000
+   ```   
+4. Produce invalid records to the topic.  You will see the producer reject the invalid records with an exception.
+   ```sh
+   cat record-examples/invalid-person-invalid-age.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
+   ```
+   
+   ```sh
+   cat record-examples/invalid-person-malformed.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
+   ```
+
+5. Consume messages showing that no rejected records reached the broker.
+   ```sh
+    oc run -n kafka-proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic people --from-beginning --timeout-ms 10000
+   ```   
+
+# Cleaning up
+
+When you have finished with this example, you can remove it from the OpenShift Cluster like this:
+
+```sh
+oc delete -k cluster-ip
+```

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -38,15 +38,15 @@ so that the effects of the validation can be observed.
    ```sh
    oc run -n kafka-proxy -qi create-topic --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic people
    ```
-2. Produce a record to the topic with a record value that matches the schema.
+2. Produce a record to the topic with a record value that matches the schema:
    ```sh
    cat record-examples/valid-person.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
    ```
-3. Consume messages showing the record reached the broker.
+3. Consume messages showing the record reached the broker:
    ```sh
     oc run -n kafka-proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic people --from-beginning --timeout-ms 10000
    ```   
-4. Produce invalid records to the topic to be rejected by the filter.  The producer will report an exception.
+4. Produce invalid records to the topic to be rejected by the filter.  The producer will report an exception:
    ```sh
    cat record-examples/invalid-person-invalid-age.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
    ```
@@ -55,7 +55,7 @@ so that the effects of the validation can be observed.
    cat record-examples/invalid-person-malformed.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
    ```
 
-5. Consume messages showing that no rejected records reached the broker.
+5. Consume messages showing that no rejected records reached the broker:
    ```sh
     oc run -n kafka-proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic people --from-beginning --timeout-ms 10000
    ```   

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -6,7 +6,7 @@ Registry is deployed to the cluster too.
 The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
 any records sent to a topic called `people` adhere to a `person` schema.
 
-Finally, kafka command line tools are used to send valid and invalid record to the `people` topic
+Finally, kafka command line (run on cluster) tools are used to send valid and invalid record to the `people` topic
 so that the effects of the validation can be observed.
 
 # Prerequisites

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -13,7 +13,7 @@ so that the effects of the validation can be observed.
 * Administrative access to the OpenShift Cluster being used to evaluate Streams for Apache Kafka Proxy
 * Streams for Apache Kafka Operator (installed cluster wide)
 * Red Hat build of Apicurio Registry Operator (installed cluster wide)
-* OpenShift CLI (oc)
+* OpenShift CLI (`oc`)
 * cURL
 
 # Deploying the Example

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -14,7 +14,8 @@ so that the effects of the validation can be observed.
 * Streams for Apache Kafka Operator (installed cluster wide)
 * Red Hat build of Apicurio Registry Operator (installed cluster wide)
 * OpenShift CLI (`oc`)
-* cURL
+* `cURL`
+* Apache Kafka CLI tools (`kafka-topics.sh`, `kafka-console-producer.sh`, and `kafka-console-consumer.sh`) found in the `bin` directory of the Streams for Apache Kafka on RHEL distribution
 
 # Deploying the Example
 

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -46,7 +46,7 @@ so that the effects of the validation can be observed.
    ```sh
     oc run -n kafka-proxy proxy-consumer -qi --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server proxy-service:9092 --topic people --from-beginning --timeout-ms 10000
    ```   
-4. Produce invalid records to the topic.  You will see the producer reject the invalid records with an exception.
+4. Produce invalid records to the topic to be rejected by the filter.  The producer will report an exception.
    ```sh
    cat record-examples/invalid-person-invalid-age.json | oc run -n kafka-proxy -qi proxy-producer --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server proxy-service:9092 --topic people --sync
    ```

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -2,7 +2,7 @@
 
 In this example, an instance of Apache Kafka is deployed to an OpenShift cluster using Streams for Apache Kafka, alongside Apicurio Registry, which is also deployed to the cluster.
 
-The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
+The Streams for Apache Kafka Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
 any records sent to a topic called `people` adhere to a `person` schema.
 
 Finally, kafka command line (run on cluster) tools are used to send valid and invalid record to the `people` topic

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -1,7 +1,6 @@
 # Streams for Apache Kafka Proxy Record Validation, exposed using Cluster-IP
 
-In this example, an instance of Apache Kafka is deployed using Streams for Apache Kafka.  Apicurio
-Registry is deployed to the cluster too.
+In this example, an instance of Apache Kafka is deployed to an OpenShift cluster using Streams for Apache Kafka, alongside Apicurio Registry, which is also deployed to the cluster.
 
 The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
 any records sent to a topic called `people` adhere to a `person` schema.

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -61,7 +61,7 @@ so that the effects of the validation can be observed.
 
 # Cleaning up
 
-When you have finished with this example, you can remove it from the OpenShift Cluster like this:
+When you have finished with this example, you can remove it from the OpenShift Cluster:
 
 ```sh
 oc delete -k cluster-ip

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -5,7 +5,7 @@ In this example, an instance of Apache Kafka is deployed to an OpenShift cluster
 The Streams for Apache Kafka Proxy is deployed with configuration to perform record validation.  The configuration ensures that 
 any records sent to a topic called `people` adhere to a `person` schema.
 
-Finally, kafka command line (run on cluster) tools are used to send valid and invalid record to the `people` topic
+Finally, Kafka command line tools are used to send valid and invalid records to the `people` topic, so the effects of the validation can be observed.
 so that the effects of the validation can be observed.
 
 # Prerequisites

--- a/examples/proxy/record-validation/cluster-ip/README.md
+++ b/examples/proxy/record-validation/cluster-ip/README.md
@@ -36,7 +36,7 @@ so that the effects of the validation can be observed.
 
 1. Create a topic `people` on the cluster, via the proxy:
    ```sh
-   oc run -n kafka-proxy -qi create-topic --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server proxy-service:9092 --create -topic people
+   oc run -n kafka-proxy -qi create-topic --image=registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server proxy-service:9092 --create --topic people
    ```
 2. Produce a record to the topic with a record value that matches the schema:
    ```sh

--- a/examples/proxy/record-validation/cluster-ip/kustomization.yaml
+++ b/examples/proxy/record-validation/cluster-ip/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- proxy

--- a/examples/proxy/record-validation/cluster-ip/proxy/kustomization.yaml
+++ b/examples/proxy/record-validation/cluster-ip/proxy/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka-proxy
+
+resources:
+- proxy-service.yaml
+- proxy-config.yaml
+

--- a/examples/proxy/record-validation/cluster-ip/proxy/proxy-config.yaml
+++ b/examples/proxy/record-validation/cluster-ip/proxy/proxy-config.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+data:
+  config.yaml: |
+    adminHttp:
+      port: 9190
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      my-cluster-proxy:
+        # the virtual cluster is kafka proxy that sits between kafka clients and the real kafka cluster.  clients
+        # connect to the virtual cluster rather than real cluster.
+        clusterNetworkAddressConfigProvider:
+          # this is the networking scheme used to present the virtual cluster on the network
+          type: PortPerBrokerClusterNetworkAddressConfigProvider
+          config:
+            # this is the address the clients will refer to in their bootstrap.servers configuration.
+            bootstrapAddress: localhost:9092
+            brokerAddressPattern: proxy-service.kafka-proxy.svc.cluster.local
+            brokerStartPort: 19092
+            numberOfBrokerPorts: 3
+        targetCluster:
+          # declares the kafka cluster that is being proxied
+          bootstrap_servers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+        logFrames: false
+    filters:
+    - type: RecordValidation
+      config:
+        rules:
+        - topicNames:
+            - people
+          valueRule:
+            schemaValidationConfig:
+              apicurioGlobalId: 1
+              apicurioRegistryUrl: http://registry-service.schema-registry.svc.cluster.local:8080

--- a/examples/proxy/record-validation/cluster-ip/proxy/proxy-service.yaml
+++ b/examples/proxy/record-validation/cluster-ip/proxy/proxy-service.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-service
+spec:
+  type: ClusterIP
+  selector:
+    app: proxy
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 19092
+  - name: port-19092
+    protocol: TCP
+    port: 19092
+    targetPort: 19092
+  - name: port-19093
+    protocol: TCP
+    port: 19093
+    targetPort: 19093
+  - name: port-19094
+    protocol: TCP
+    port: 19094
+    targetPort: 19094
+

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -23,7 +23,7 @@ so that the effects of the validation can be observed.
    ```sh
    oc apply -k load-balancer
    ```
-2. Get the external address of the proxy service
+2. Get the external address of the proxy service:
    ```sh
    LOAD_BALANCER_ADDRESS=$(oc get service -n kafka-proxy proxy-service --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
    ```

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -3,7 +3,7 @@
 In this example, an instance of Apache Kafka is deployed using Streams for Apache Kafka.  Apicurio
 Registry is deployed to the cluster too.
 
-The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that
+The Streams for Apache Kafka Proxy is deployed with configuration to perform record validation.  The configuration ensures that
 any records sent to a topic called `people` adhere to a `person` schema.
 
 Finally, kafka command line tools (run off cluster) are used to send valid and invalid record to the `people` topic

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -19,7 +19,7 @@ so that the effects of the validation can be observed.
 
 # Deploying the Example
 
-1. Deploy the Example
+1. Deploy the Example:
    ```sh
    oc apply -k load-balancer
    ```

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -27,7 +27,7 @@ so that the effects of the validation can be observed.
    ```sh
    LOAD_BALANCER_ADDRESS=$(oc get service -n kafka-proxy proxy-service --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
    ```
-3. Now update the `brokerAddressPattern:` to match the `LOAD_BALANCER_ADDRESS`:
+3. Update the `brokerAddressPattern:` to match the `LOAD_BALANCER_ADDRESS`:
    ```sh
      sed -i  "s/\(brokerAddressPattern:\).*$/\1 ${LOAD_BALANCER_ADDRESS}/" load-balancer/proxy/proxy-config.yaml
    ```

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -31,7 +31,7 @@ so that the effects of the validation can be observed.
    ```sh
      sed -i  "s/\(brokerAddressPattern:\).*$/\1 ${LOAD_BALANCER_ADDRESS}/" load-balancer/proxy/proxy-config.yaml
    ```
-4. Reapply and bounce:
+4. Update the load balancer and restart the pods:
    ```sh
       oc apply -k load-balancer && oc delete pod -n proxy --all
    ```

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -10,13 +10,12 @@ so that the effects of the validation can be observed.
 
 # Prerequisites
 
-* [KMS is prepared](../PREPARE_KMS.md).
-* Vault CLI
-
-* Administrative access to the OpenShift Cluster being used to evaluate AMQ Stream Proxy
-* OpenShift CLI (oc)
-* Streams for Apache Kafka Operator is installed namespace wide
-* Apache Kafka CLI tools (`kafka-topics.sh`, `kafka-console-producer.sh`, and `kafka-console-consumer.sh`) found in the `bin` directory of the Streams for Apache Kafka on RHEL distribution.
+* Administrative access to the OpenShift Cluster being used to evaluate Streams for Apache Kafka Proxy
+* Streams for Apache Kafka Operator (installed cluster wide)
+* Red Hat build of Apicurio Registry Operator (installed cluster wide)
+* OpenShift CLI (`oc`)
+* `cURL`
+* Apache Kafka CLI tools (`kafka-topics.sh`, `kafka-console-producer.sh`, and `kafka-console-consumer.sh`) found in the `bin` directory of the Streams for Apache Kafka on RHEL distribution
 
 # Deploying the Example
 

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -1,0 +1,86 @@
+# Streams for Apache Kafka Proxy Record Validation, exposed by External Load Balancer
+
+In this example, an instance of Apache Kafka is deployed using Streams for Apache Kafka.  Apicurio
+Registry is deployed to the cluster too.
+
+The Streams Proxy is deployed with configuration to perform record validation.  The configuration ensures that
+any records sent to a topic called `people` adhere to a `person` schema.
+
+Finally, kafka command line tools (run off cluster) are used to send valid and invalid record to the `people` topic
+so that the effects of the validation can be observed.
+
+# Prerequisites
+
+* [KMS is prepared](../PREPARE_KMS.md).
+* Vault CLI
+
+* Administrative access to the OpenShift Cluster being used to evaluate AMQ Stream Proxy
+* OpenShift CLI (oc)
+* Streams for Apache Kafka Operator is installed namespace wide
+* Apache Kafka CLI tools (`kafka-topics.sh`, `kafka-console-producer.sh`, and `kafka-console-consumer.sh`) found in the `bin` directory of the Streams for Apache Kafka on RHEL distribution.
+
+# Deploying the Example
+
+1. Deploy the Example
+   ```sh
+   oc apply -k load-balancer
+   ```
+2. Get the external address of the proxy service
+   ```sh
+   LOAD_BALANCER_ADDRESS=$(oc get service -n kafka-proxy proxy-service --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+   ```
+3. Now update the `brokerAddressPattern:` to match the `LOAD_BALANCER_ADDRESS`:
+   ```sh
+     sed -i  "s/\(brokerAddressPattern:\).*$/\1 ${LOAD_BALANCER_ADDRESS}/" load-balancer/proxy/proxy-config.yaml
+   ```
+4. Reapply and bounce:
+   ```sh
+      oc apply -k load-balancer && oc delete pod -n proxy --all
+   ```
+
+5. Create the example schema in the registry:
+
+   ```sh
+   REGISTRY_URL=http://$(oc get apicurioregistries.registry.apicur.io -n schema-registry registry --template='{{.status.info.host}}')
+   curl -X POST ${REGISTRY_URL}/apis/registry/v2/groups/default/artifacts -H "Content-Type: application/json; artifactType=JSON" -H "X-Registry-ArtifactId: Person" --data @schemas/person.schema.json
+   ```
+
+# Try out the example
+
+1. Create a topic `people` on the cluster, via the proxy:
+   ```sh
+   kafka-topics.sh --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --create -topic people
+   ```
+   Note it may take a minute or two for `${LOAD_BALANCER_ADDRESS}` to resolve in your environment and for the load balancer to begin routing
+   network traffic.
+
+2. Produce a record to the topic with a record value that matches the schema.
+   ```sh
+   cat record-examples/valid-person.json |  kafka-console-producer.sh --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --sync
+   ```
+3. Consume messages showing the record reached the broker.
+   ```sh
+    kafka-console-consumer.sh  --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --from-beginning --timeout-ms 10000
+   ```   
+4. Produce invalid records to the topic.  You will see the producer reject the invalid records with an exception.
+   ```sh
+   cat record-examples/invalid-person-invalid-age.json | kafka-console-producer.sh --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --sync
+   ```
+
+   ```sh
+   cat record-examples/invalid-person-malformed.json | kafka-console-producer.sh --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --sync
+   ```
+
+5. Consume messages showing that no rejected records reached the broker.
+   ```sh
+    kafka-console-consumer.sh  --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --from-beginning --timeout-ms 10000
+   ```   
+
+# Cleaning up
+
+When you have finished with this example, you can remove it from the OpenShift Cluster like this:
+
+```sh
+oc delete -k load-balancer
+```
+

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -1,7 +1,6 @@
 # Streams for Apache Kafka Proxy Record Validation, exposed by External Load Balancer
 
-In this example, an instance of Apache Kafka is deployed using Streams for Apache Kafka.  Apicurio
-Registry is deployed to the cluster too.
+In this example, an instance of Apache Kafka is deployed to an OpenShift cluster using Streams for Apache Kafka, alongside Apicurio Registry, which is also deployed to the cluster.
 
 The Streams for Apache Kafka Proxy is deployed with configuration to perform record validation.  The configuration ensures that
 any records sent to a topic called `people` adhere to a `person` schema.

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -61,7 +61,7 @@ so that the effects of the validation can be observed.
    ```sh
     kafka-console-consumer.sh  --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --from-beginning --timeout-ms 10000
    ```   
-4. Produce invalid records to the topic.  You will see the producer reject the invalid records with an exception.
+4. Produce invalid records to the topic to be rejected by the filter.  The producer will report an exception.
    ```sh
    cat record-examples/invalid-person-invalid-age.json | kafka-console-producer.sh --bootstrap-server ${LOAD_BALANCER_ADDRESS}:9092 --topic people --sync
    ```

--- a/examples/proxy/record-validation/load-balancer/README.md
+++ b/examples/proxy/record-validation/load-balancer/README.md
@@ -78,7 +78,7 @@ so that the effects of the validation can be observed.
 
 # Cleaning up
 
-When you have finished with this example, you can remove it from the OpenShift Cluster like this:
+When you have finished with this example, you can remove it from the OpenShift Cluster:
 
 ```sh
 oc delete -k load-balancer

--- a/examples/proxy/record-validation/load-balancer/kustomization.yaml
+++ b/examples/proxy/record-validation/load-balancer/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- proxy

--- a/examples/proxy/record-validation/load-balancer/proxy/kustomization.yaml
+++ b/examples/proxy/record-validation/load-balancer/proxy/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka-proxy
+
+resources:
+- proxy-service.yaml
+- proxy-config.yaml
+

--- a/examples/proxy/record-validation/load-balancer/proxy/proxy-config.yaml
+++ b/examples/proxy/record-validation/load-balancer/proxy/proxy-config.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: proxy-config
+data:
+  config.yaml: |
+    adminHttp:
+      port: 9190
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      my-cluster-proxy:
+        # the virtual cluster is kafka proxy that sits between kafka clients and the real kafka cluster.  clients
+        # connect to the virtual cluster rather than real cluster.
+        clusterNetworkAddressConfigProvider:
+          # this is the networking scheme used to present the virtual cluster on the network
+          type: PortPerBrokerClusterNetworkAddressConfigProvider
+          config:
+            # this is the address the clients will refer to in their bootstrap.servers configuration.
+            bootstrapAddress: localhost:9092
+            brokerAddressPattern: aad5a82ca85ec48419a72d2a6d1b3d12-9280ad3d8feae0f1.elb.us-east-1.amazonaws.com
+            brokerStartPort: 19092
+            numberOfBrokerPorts: 3
+        targetCluster:
+          # declares the kafka cluster that is being proxied
+          bootstrap_servers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+        logFrames: false
+    filters:
+      - type: RecordValidation
+        config:
+          rules:
+            - topicNames:
+                - people
+              valueRule:
+                schemaValidationConfig:
+                  apicurioGlobalId: 1
+                  apicurioRegistryUrl: http://registry-service.schema-registry.svc.cluster.local:8080

--- a/examples/proxy/record-validation/load-balancer/proxy/proxy-service.yaml
+++ b/examples/proxy/record-validation/load-balancer/proxy/proxy-service.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: red-hat-managed=true  # workaround for https://issues.redhat.com/browse/OSD-20193
+spec:
+  type: LoadBalancer
+  selector:
+    app: proxy
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 19092
+  - name: port-19092
+    protocol: TCP
+    port: 19092
+    targetPort: 19092
+  - name: port-19093
+    protocol: TCP
+    port: 19093
+    targetPort: 19093
+  - name: port-19094
+    protocol: TCP
+    port: 19094
+    targetPort: 19094
+

--- a/examples/proxy/record-validation/record-examples/invalid-person-invalid-age.json
+++ b/examples/proxy/record-validation/record-examples/invalid-person-invalid-age.json
@@ -1,0 +1,1 @@
+{"firstName":"john","lastName":"smith", "age" : -1}

--- a/examples/proxy/record-validation/record-examples/invalid-person-malformed.json
+++ b/examples/proxy/record-validation/record-examples/invalid-person-malformed.json
@@ -1,0 +1,1 @@
+this isn't json at all

--- a/examples/proxy/record-validation/record-examples/valid-person.json
+++ b/examples/proxy/record-validation/record-examples/valid-person.json
@@ -1,0 +1,1 @@
+{"firstName":"john","lastName":"smith","age":23}

--- a/examples/proxy/record-validation/schemas/person.schema.json
+++ b/examples/proxy/record-validation/schemas/person.schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}


### PR DESCRIPTION
ENTMQSTPR-48: record validation example

why: 2.8 supports record validation against JSON schemas in Apicurio Schema Registry.

Note: When testing the example, switch the image to the upstream.'s

quay.io/kroxylicious/kroxylicious:0.8.0