### PR TITLE
ENTMQST-6263: Switch to FIPS friendly 9.2 minimal base image

### DIFF
--- a/bridge/image.yaml
+++ b/bridge/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/bridge-rhel9
 description: "AMQ Streams image for running the Apache Kafka bridge"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -27,8 +27,7 @@ modules:
     - name: bridge
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini
@@ -62,38 +61,6 @@ packages:
     - tini
     - net-tools
     - lsof
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 run:
   user: 1001

--- a/bridge/modules/bridge/module.yaml
+++ b/bridge/modules/bridge/module.yaml
@@ -16,7 +16,7 @@ artifacts:
     name: kafka-bridge-licenses.tar.gz
 
 packages:
-  manager: dnf
+  manager: microdnf
   install:
     - unzip
     - tar

--- a/drain-cleaner/image.yaml
+++ b/drain-cleaner/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/drain-cleaner-rhel9
 description: "AMQ Streams image for running the AMQ Streams Drain Cleaner"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -27,8 +27,7 @@ modules:
     - name: drain-cleaner
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini
@@ -57,38 +56,6 @@ packages:
   install:
     - java-17-openjdk-devel
     - tini
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 ports:
     - value: 8080

--- a/drain-cleaner/modules/drain-cleaner/module.yaml
+++ b/drain-cleaner/modules/drain-cleaner/module.yaml
@@ -14,7 +14,7 @@ artifacts:
     name: drain-cleaner-licenses.tar.gz
 
 packages:
-  manager: dnf
+  manager: microdnf
   install:
     - unzip
     - tar

--- a/kafka/kafka-3.6.0/image.yaml
+++ b/kafka/kafka-3.6.0/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/kafka-36-rhel9
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect, Mirror Maker and Cruise Control"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -26,8 +26,7 @@ modules:
       version: 3.6.0
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini and kafka exporter
@@ -65,38 +64,6 @@ packages:
     - tini
     - lsof
     - tzdata
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 run:
   user: 1001

--- a/kafka/kafka-3.7.0/image.yaml
+++ b/kafka/kafka-3.7.0/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/kafka-37-rhel9
 description: "AMQ Streams image for running Apache Kafka, Zookeeper, Kafka Connect, Mirror Maker and Cruise Control"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -26,8 +26,7 @@ modules:
       version: 3.7.0
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini and kafka exporter
@@ -65,38 +64,6 @@ packages:
     - tini
     - lsof
     - tzdata
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 run:
   user: 1001

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -22,7 +22,7 @@ artifacts:
     name: cruise-control-ocp.zip
 
 packages:
-  manager: dnf
+  manager: microdnf
   install:
     - unzip
     - tar

--- a/maven-builder/image.yaml
+++ b/maven-builder/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/maven-builder-rhel9
 description: "AMQ Streams image for build custom Kafka Connect images"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -27,8 +27,7 @@ modules:
     - name: maven-builder
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini
@@ -62,38 +61,6 @@ packages:
     - hostname
     - net-tools
     - lsof
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 run:
   user: 1001

--- a/maven-builder/modules/maven-builder/module.yaml
+++ b/maven-builder/modules/maven-builder/module.yaml
@@ -10,7 +10,7 @@ envs:
     value: "amqstreams-maven-builder-container"
 
 packages:
-  manager: dnf
+  manager: microdnf
   install:
     - unzip
     - tar

--- a/operator/image.yaml
+++ b/operator/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: amq-streams/strimzi-rhel9-operator
 description: "AMQ Streams image for the Cluster, Topic, User Operators, and Kafka init"
 version: "2.7.0"
-from: registry.redhat.io/rhel9-2-els/rhel
+from: registry.redhat.io/rhel9-2-els/rhel-minimal
 
 labels:
   - name: "com.redhat.component"
@@ -27,8 +27,7 @@ modules:
     - name: operator
 
 packages:
-  manager: dnf
-  manager_flags: --setopt=tsflags=nodocs --setopt=install_weak_deps=0
+  manager: microdnf
   content_sets:
     x86_64:
       # Required for tini
@@ -63,38 +62,6 @@ packages:
     - net-tools
     - lsof
     - bind-utils
-  remove:
-    - vim-minimal
-    - subscription-manager
-    - shadow-utils
-    - libuser
-    - python3-gobject-base
-    - libnl3
-    - python3-chardet
-    - usermode
-    - python3-dnf-plugins-core
-    - gdb-gdbserver
-    - python3-urllib3
-    - python3-dateutil
-    - python3-dbus
-    - python3-idna
-    - passwd
-    - python3-subscription-manager-rhsm
-    - python3-requests
-    - libsemanage
-    - dmidecode
-    - acl
-    - crypto-policies-scripts
-    - python3-librepo
-    - python3-iniparse
-    - python3-six
-    - python3-ethtool
-    - which
-    - python3-pysocks
-    - python3-cloud-what
-    - python3-decorator
-    - virt-what
-    - subscription-manager-rhsm-certificates
 
 run:
   user: 1001

--- a/operator/modules/operator/module.yaml
+++ b/operator/modules/operator/module.yaml
@@ -24,7 +24,7 @@ artifacts:
     name: strimzi-operator-scripts.zip
 
 packages:
-  manager: dnf
+  manager: microdnf
   install:
     - unzip
     - tar


### PR DESCRIPTION
Red Hat now has a RHEL analogue for the UBI minimal.  Switching to this will reduce our container sizes and reduce the possibility for spurious CVEs.

This switches to the minimal base image, and reverts the package manager back to microdnf.  It also removes the package removals we added to slim down the fat image.

I tested this change against Proxy - no issues found.
