### PR TITLE
Automation to update Install and Examples files during new release Backport

### DIFF
--- a/core_automation/README.md
+++ b/core_automation/README.md
@@ -2,6 +2,7 @@
 
 Python scripts to backport the following files from upstream:
 - [examples](https://github.com/strimzi/strimzi-kafka-operator/tree/main/examples)
+- [install](https://github.com/strimzi/strimzi-kafka-operator/tree/main/install)
 
 Make sure you are on the amqstreams<__version__>-dev branch and run:
 ```

--- a/core_automation/main.py
+++ b/core_automation/main.py
@@ -3,30 +3,98 @@
  FILE: main.py
 ########################################################"""
 import os
-from modules import backport_examples
-from modules import versions
+from modules import backport_examples, backport_install, versions
 
+def get_paths(target_strimzi_version):
+    """Helper function to build commonly used paths."""
+    base_dir = f"strimzi-{target_strimzi_version}"
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    return {
+        'example_dir': os.path.join(base_dir, "examples"),
+        'full_example_dir': f"{base_dir}/examples",
+        'base_dir': base_dir,
+        'full_base_dir': os.path.join(current_dir, base_dir),
+        'example_dir_to_compare': "../examples"
+    }
 
-def main():
-    target_product_version = versions.get_product_version(versions.get_branch_name())
-    target_strimzi_version = versions.get_target_strimzi_version(target_product_version)
-    kafka_version_to_replace = versions.get_kafka_version_to_replace(target_product_version)
-    kafka_version_replacement = versions.get_kafka_version_replacement(target_product_version)
-    target_example_dir_path = ("strimzi-" + target_strimzi_version + "/examples")
-    target_example_dir_path2 = "../examples"
-    example_files_to_delete = [
-        os.path.join("strimzi-" + target_strimzi_version, "examples/security/keycloak-authorization/README.md"),
-        os.path.join("strimzi-" + target_strimzi_version, "examples/connect/kafka-connect-build.yaml"),
+def get_file_and_directory_deletions(target_strimzi_version):
+    """Helper function to return files and directories that need to be deleted."""
+    base_dir = f"strimzi-{target_strimzi_version}"
+
+    files = [
+        os.path.join(base_dir, "examples/security/keycloak-authorization/README.md"),
+        os.path.join(base_dir, "examples/connect/kafka-connect-build.yaml"),
+        os.path.join(base_dir, "examples/kafka/kafka-with-node-pools.yaml"),
+        os.path.join(base_dir, "CHANGELOG.md"),
     ]
-    strimzi_dir = "strimzi-" + target_strimzi_version
+
+    directories = [
+        os.path.join(base_dir, "docs"),
+        os.path.join(base_dir, "install/drain-cleaner/certmanager"),
+        os.path.join(base_dir, "install/drain-cleaner/kubernetes"),
+        os.path.join(base_dir, "examples/kafka/kraft")
+    ]
+
+    return files, directories
+
+def backport_example_files(target_strimzi_version, kafka_version_to_replace, kafka_version_replacement):
+    """Helper function to handle all backport example operations."""
+    paths = get_paths(target_strimzi_version)
+
     backport_examples.create_release_url_for_zips(target_strimzi_version)
     backport_examples.unpack_zips(target_strimzi_version)
-    backport_examples.compare_directory_files(target_example_dir_path, target_example_dir_path2)
-    backport_examples.update_yaml_files("strimzi-" + target_strimzi_version + "/examples", kafka_version_to_replace,
-                                        kafka_version_replacement)
-    backport_examples.delete_file(*example_files_to_delete)
-    backport_examples.update_example_dir_readme('strimzi-' + target_strimzi_version + '/examples', 'README.md')
-    backport_examples.copy_directory("examples", "examples", strimzi_dir)
+    backport_examples.compare_directory_files(paths['example_dir'], paths['example_dir_to_compare'])
+    backport_examples.update_yaml_files(paths['full_example_dir'], kafka_version_to_replace, kafka_version_replacement)
+
+    files, directories = get_file_and_directory_deletions(target_strimzi_version)
+    backport_examples.delete_file(*files)
+    backport_examples.delete_directory(*directories)
+
+    backport_examples.update_example_dir_readme(paths['full_example_dir'], 'README.md')
+    backport_examples.copy_directory_excluding_readme("examples", "examples", paths['base_dir'])
+
+def backport_install_files(target_strimzi_version, target_release_version):
+    """Helper function to handle all backport installation operations."""
+    paths = get_paths(target_strimzi_version)
+
+    file_paths = [
+        "/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml",
+        "/install/drain-cleaner/openshift/060-Deployment.yaml",
+        "/install/topic-operator/05-Deployment-strimzi-topic-operator.yaml",
+        "/install/user-operator/05-Deployment-strimzi-user-operator.yaml"
+    ]
+
+    files, directories = get_file_and_directory_deletions(target_strimzi_version)
+
+    backport_install.delete_directory(*directories)
+    backport_install.update_cluster_operator_deployment(f"{paths['full_base_dir']}/{file_paths[0]}", target_release_version)
+
+    # Update deployments
+    deployments = [
+        (file_paths[1], "drain-cleaner", "application"),
+        (file_paths[2], "topic-operator", "infrastructure"),
+        (file_paths[3], "user-operator", "infrastructure")
+    ]
+    for file_path, component, kind in deployments:
+        backport_install.update_deployment(f"{paths['full_base_dir']}{file_path}", target_release_version, component, kind)
+
+    backport_install.delete_excluded_directory('canary', 'install', paths['base_dir'])
+    backport_install.copy_directory("install", "install", paths['base_dir'])
+
+def main():
+    """Main entry point"""
+    target_product_version = versions.get_product_version(versions.get_branch_name())
+    target_strimzi_version = versions.get_target_strimzi_version(target_product_version)
+    target_release_version = versions.get_target_micro_release_version()
+
+    kafka_version_to_replace = versions.get_kafka_version_to_replace(target_product_version)
+    kafka_version_replacement = versions.get_kafka_version_replacement(target_product_version)
+
+    backport_example_files(target_strimzi_version, kafka_version_to_replace, kafka_version_replacement)
+    backport_install_files(target_strimzi_version, target_release_version)
+
+    # Clean up created upstream resources
+    strimzi_dir = f"strimzi-{target_strimzi_version}"
     backport_examples.delete_created_upstream_resources(strimzi_dir)
 
 

--- a/core_automation/modules/backport_examples.py
+++ b/core_automation/modules/backport_examples.py
@@ -48,7 +48,6 @@ def update_yaml_files(directory, version_to_replace, replacement):
                 with open(file_path, 'r') as f:
                     content = f.read()
                 content = content.replace(version_to_replace, str(replacement))
-                print(version_to_replace, str(replacement))
                 with open(file_path, 'w') as f:
                     f.write(content)
 
@@ -59,7 +58,8 @@ def update_example_dir_readme(examples_dir, file_name):
     try:
         with open(readme_file_path, 'r') as f:
             content = f.read()
-        content = content.replace('Strimzi', 'AMQ Streams').replace('strimzi', 'AMQ Streams')
+        content = content.replace('Strimzi', 'Red Hat Streams for Apache Kafka').replace('strimzi',
+                                                                                         'Red Hat Streams for Apache Kafka ')
         content = content.replace('* JMX Trans deployment', '')
         with open(readme_file_path, 'w') as f:
             f.write(content)
@@ -78,14 +78,45 @@ def delete_file(*file_paths):
             print(f'Error deleting file {file_path}: {e}')
 
 
-# copy upstream directory to downstream directory
-def copy_directory(source_name, dest_name, strimzi_dir):
+def delete_directory(*file_paths):
+    for file_path in file_paths:
+        try:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+                print(f'Successfully deleted file: {file_path}')
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+                print(f'Successfully deleted directory and its contents: {file_path}')
+            else:
+                print(f'File or directory not found: {file_path}')
+        except OSError as e:
+            print(f'Error deleting file or directory {file_path}: {e}')
+
+
+def copy_directory_excluding_readme(source_name, dest_name, strimzi_dir):
     source_dir = os.path.join(strimzi_dir, source_name)
     dest_dir = f'../{dest_name}'
+
     try:
-        shutil.copytree(source_dir, dest_dir,
-                        dirs_exist_ok=True)  # Copy the contents of the source directory to the destination
-        print(f'{source_name} directory copied to {dest_name} successfully.')
+        # Create the destination directory if it doesn't exist
+        os.makedirs(dest_dir, exist_ok=True)
+
+        # Iterate over the items in the source directory
+        for item in os.listdir(source_dir):
+            source_item = os.path.join(source_dir, item)
+            dest_item = os.path.join(dest_dir, item)
+
+            # Skip README.md
+            if item == 'README.md':
+                continue
+
+            # Copy files or directories
+            if os.path.isdir(source_item):
+                shutil.copytree(source_item, dest_item, dirs_exist_ok=True)
+            else:
+                shutil.copy2(source_item, dest_item)
+
+        print(f'{source_name} directory copied to {dest_name} successfully, excluding README.md.')
     except Exception as e:
         print(f'Error copying {source_name} directory to {dest_name}:', e)
 

--- a/core_automation/modules/backport_install.py
+++ b/core_automation/modules/backport_install.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""########################################################
+ FILE: backport_install.py
+########################################################"""
+import datetime
+import shutil
+import os
+
+from ruamel import yaml
+from ruamel.yaml import YAML
+from core_automation.modules import versions
+
+
+def represent_multiline_str(representer, data):
+    if '\n' in data:
+        return representer.represent_scalar(tag='tag:yaml.org,2002:str', value=data, style='|')
+    return representer.represent_scalar(tag='tag:yaml.org,2002:str', value=data)
+
+
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.representer.add_representer(str, represent_multiline_str)
+yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+def get_common_fields(yaml_data):
+    common_fields = {}
+    common_fields["labels_field"] = yaml_data["spec"]["template"]["metadata"]["labels"]
+    common_fields["env_field"] = yaml_data["spec"]["template"]["spec"]["containers"][0]["env"]
+    common_fields["common_registry_url"] = "registry.redhat.io/amq-streams/"
+    common_fields["current_year"], common_fields["current_quarter"] = get_current_year_and_quarter()
+    last_year, last_quarter = get_last_year_and_quarter()  # Getting last year and quarter
+    common_fields["last_year"] = last_year
+    common_fields["last_quarter"] = last_quarter
+    common_fields["current_kafka_version"] = get_current_kafka_version()
+    common_fields["target_kafka_version"] = get_target_kafka_version()
+    common_fields["current_kafka_registry_version"] = get_current_kafka_registry_version()
+    common_fields["target_kafka_registry_version"] = get_target_kafka_registry_version()
+    common_fields["current_release_quarter"] = str(last_year) + ".Q" + str(last_quarter)
+    common_fields["target_release_quarter"] = str(common_fields["current_year"]) + ".Q" + str(
+        common_fields["current_quarter"])
+    return common_fields
+
+
+def get_current_kafka_version():
+    kafka_version = versions.get_kafka_version_to_replace(versions.get_product_version(versions.get_branch_name()))
+    return f"{kafka_version}.0"
+
+
+def get_target_kafka_version():
+    kafka_version = versions.get_kafka_version_replacement(versions.get_product_version(versions.get_branch_name()))
+    return f"{kafka_version}.0"
+
+
+def get_current_kafka_registry_version():
+    kafka_registry_version = versions.get_kafka_version_to_replace(
+        versions.get_product_version(versions.get_branch_name()))
+    kafka_registry_version = str(kafka_registry_version).replace(".", "")
+    return kafka_registry_version
+
+
+def get_target_kafka_registry_version():
+    kafka_registry_version = versions.get_kafka_version_replacement(
+        versions.get_product_version(versions.get_branch_name()))
+    kafka_registry_version = str(kafka_registry_version).replace(".", "")
+    return kafka_registry_version
+
+
+def get_current_streams_version():
+    streams_version = versions.get_target_streams_minor_version()
+    return streams_version
+
+
+def get_current_year_and_quarter():
+    now = datetime.datetime.now()
+    year = now.year
+    month = now.month
+
+    # Determine quarter based on month
+    if month <= 3:
+        quarter = 1
+    elif month <= 6:
+        quarter = 2
+    elif month <= 9:
+        quarter = 3
+    else:
+        quarter = 4
+    return year, quarter
+
+
+def get_last_year_and_quarter():
+    current_year, current_quarter = get_current_year_and_quarter()
+
+    if current_quarter == 1:
+        last_year = current_year - 1
+        last_quarter = 4
+    else:
+        last_year = current_year
+        last_quarter = current_quarter - 1
+    return last_year, last_quarter
+
+
+def format_year_and_quarter():
+    year, quarter = get_current_year_and_quarter()
+    formatted_quarter = str(f"{year}.Q{quarter}")
+    return formatted_quarter
+
+
+def generate_env_var(name, subcomp, subcomp_t):
+    env_common = {
+        "com.company": "Red_Hat",
+        "rht.prod_name": "Red_Hat_Application_Foundations",
+        "rht.prod_ver": format_year_and_quarter(),
+        "rht.comp": "AMQ_Streams",
+        "rht.comp_ver": get_current_streams_version(),
+        "rht.subcomp": subcomp,
+        "rht.subcomp_t": subcomp_t
+    }
+    value = "\n".join(f"{key}={value}" for key, value in env_common.items())
+    return {
+        "name": name,
+        "value": value
+    }
+
+
+def update_cluster_operator_deployment(file_path, release_version):
+    with open(file_path, "r") as file:
+        yaml_data = yaml.load(file)
+    common_fields = get_common_fields(yaml_data)
+    containers = yaml_data["spec"]["template"]["spec"]["containers"]
+    env_vars = yaml_data["spec"]["template"]["spec"]["containers"][0]["env"]
+    labels = yaml_data["spec"]["template"]["metadata"]["labels"]
+
+    KAFKA_ENV_VARS_TO_UPDATE = ["STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE",
+                                "STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE",
+                                "STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE"]
+    STRIMZI_ENV_VARS_TO_UPDATE = ["STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE",
+                                  "STRIMZI_DEFAULT_USER_OPERATOR_IMAGE",
+                                  "STRIMZI_DEFAULT_KAFKA_INIT_IMAGE"]
+    KAFKA_MULTI_ENV_VARS_TO_UPDATE = ["STRIMZI_KAFKA_IMAGES",
+                                      "STRIMZI_KAFKA_CONNECT_IMAGES",
+                                      "STRIMZI_KAFKA_MIRROR_MAKER_IMAGES",
+                                      "STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES"]
+    BRIDGE_ENV_VARS_TO_UPDATE = "STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE",
+    MAVEN_ENV_VARS_TO_UPDATE = "STRIMZI_DEFAULT_MAVEN_BUILDER"
+    KANIKO_ENV_VARS = "STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE"
+    update_default_upgrade_kafka_image = f"{common_fields['current_kafka_version']}={common_fields['common_registry_url']}kafka-{common_fields['current_kafka_registry_version']}-rhel9:{release_version}"
+    update_default_target_kafka_image = f"{common_fields['target_kafka_version']}={common_fields['common_registry_url']}kafka-{common_fields['target_kafka_registry_version']}-rhel9:{release_version}"
+
+    new_env_var = {
+        'name': 'STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE',
+        'value': 'registry.redhat.io/amq-streams/kafka-37-rhel9:2.7.0'
+    }
+
+    # Insert the new environment variable after STRIMZI_OPERATION_TIMEOUT_MS
+    updated_env_vars = []
+    added = False
+    for env_var in env_vars:
+        updated_env_vars.append(env_var)
+        if env_var['name'] == "STRIMZI_OPERATION_TIMEOUT_MS" and not added:
+            updated_env_vars.append(new_env_var)
+            added = True
+    env_vars[:] = updated_env_vars
+
+    label_env = {
+        "strimzi.io/kind": "cluster-operator",
+        "com.company": "Red_Hat",
+        "rht.prod_name": "Red_Hat_Application_Foundations",
+        "rht.prod_ver": format_year_and_quarter(),
+        "rht.comp": "AMQ_Streams",
+        "rht.comp_ver": get_current_streams_version(),
+        "rht.subcomp": "cluster-operator",
+        "rht.subcomp_t": "infrastructure"
+    }
+
+    labels.update(label_env)
+    containers[0]['image'] = common_fields["common_registry_url"] + f"strimzi-rhel9-operator:{release_version}"
+    kafka_version = get_target_kafka_registry_version()
+
+    for env_var in env_vars:
+        if env_var['name'] in KAFKA_ENV_VARS_TO_UPDATE:
+            env_var['value'] = common_fields["common_registry_url"] + f"kafka-{kafka_version}-rhel9:{release_version}"
+        if env_var['name'] in STRIMZI_ENV_VARS_TO_UPDATE:
+            env_var['value'] = common_fields["common_registry_url"] + f"strimzi-rhel9-operator:{release_version}"
+        if env_var['name'] in BRIDGE_ENV_VARS_TO_UPDATE:
+            env_var['value'] = common_fields["common_registry_url"] + f"bridge-rhel9:{release_version}"
+        if env_var['name'] in MAVEN_ENV_VARS_TO_UPDATE:
+            env_var['value'] = "registry.redhat.io/ubi8/openjdk-17:1.16"
+        # *********************************************************
+        if env_var['name'] in KAFKA_MULTI_ENV_VARS_TO_UPDATE:
+            env_var['value'] = f"{update_default_upgrade_kafka_image}\n{update_default_target_kafka_image}"
+
+        # *********************************************************
+
+    # I had to allow this its own loop because for some reason MAVEN_ENV_VARS_TO_UPDATE wouldn't update**********
+    for kaniko in env_vars:
+        if kaniko['name'] == KANIKO_ENV_VARS:
+            env_vars.remove(kaniko)
+
+    service_labels = {
+        "discovery.3scale.net=true",
+    }
+
+    env_vars.append({
+        "name": "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS",
+        "value": "\n".join(service_labels)})
+
+    annotations = {
+        "discovery.3scale.net/scheme=http",
+        "discovery.3scale.net/port=8080",
+        "discovery.3scale.net/path=/",
+        "discovery.3scale.net/description-path=/openapi"
+    }
+    env_vars.append({
+        "name": "STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS",
+        "value": "\n".join(annotations)})
+
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_LABELS", "kafka-broker", "application"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS", "kafka-connect", "application"))
+    env_vars.append(
+        generate_env_var("STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS", "kafka--connect-build", "application"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_ZOOKEEPER_LABELS", "zookeeper", "infrastructure"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS", "entity-operator", "infrastructure"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS", "kafka-mirror-maker2", "application"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS", "kafka-broker", "application"))
+    env_vars.append(generate_env_var("TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS", "cruise-control", "application"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS", "kafka-bridge", "application"))
+    env_vars.append(generate_env_var("STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS", "afka-exporter", "application"))
+
+    with open(file_path, 'w') as file:
+        yaml.default_style = '|'
+        yaml.dump(yaml_data, file)
+
+
+def update_deployment(file_path, release_version, subcomp, subcomp_type):
+    with open(file_path, "r") as file:
+        yaml_data = yaml.load(file)
+    common_fields = get_common_fields(yaml_data)
+    containers = yaml_data["spec"]["template"]["spec"]["containers"]
+    labels = yaml_data["spec"]["template"]["metadata"]["labels"]
+    label_env = {
+        "com.company": "Red_Hat",
+        "rht.prod_name": "Red_Hat_Application_Foundations",
+        "rht.prod_ver": format_year_and_quarter(),
+        "rht.comp": "AMQ_Streams",
+        "rht.comp_ver": get_current_streams_version(),
+        "rht.subcomp": subcomp,
+        "rht.subcomp_t": subcomp_type
+    }
+    labels.update(label_env)
+
+    images = {
+        "drain-cleaner": "drain-cleaner-rhel9",
+        "topic-operator": "strimzi-rhel9-operator",
+        "user-operator": "strimzi-rhel9-operator"
+    }
+
+    image_name = images.get(subcomp)
+    if image_name:
+        containers[0]['image'] = f"{common_fields['common_registry_url']}{image_name}:{release_version}"
+
+    if subcomp == "drain-cleaner":
+        containers[0].update({
+            "command": [
+                "/application",
+                "-Dquarkus.http.host=0.0.0.0",
+                "--kafka",
+                "--zookeeper"
+            ]
+        })
+    # Remove the args field
+    if "args" in containers[0]:
+        del containers[0]["args"]
+
+    with open(file_path, 'w') as file:
+        yaml.dump(yaml_data, file)
+
+
+# copy upstream directory to downstream directory
+def copy_directory(source_name, dest_name, strimzi_dir):
+    source_dir = os.path.join(strimzi_dir, source_name)
+    dest_dir = f'../{dest_name}'
+    try:
+        shutil.copytree(source_dir, dest_dir,
+                        dirs_exist_ok=True)  # Copy the contents of the source directory to the destination
+        print(f'{source_name} directory copied to {dest_name} successfully.')
+    except Exception as e:
+        print(f'Error copying {source_name} directory to {dest_name}:', e)
+
+
+def delete_directory(*file_paths):
+    for file_path in file_paths:
+        try:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+                print(f'Successfully deleted file: {file_path}')
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+                print(f'Successfully deleted directory and its contents: {file_path}')
+            else:
+                print(f'File or directory not found: {file_path}')
+        except OSError as e:
+            print(f'Error deleting file or directory {file_path}: {e}')
+
+
+def delete_excluded_directory(folder_name, module_name, strimzi_dir):
+    target_dir = os.path.join(strimzi_dir, module_name)
+    delete_folder = os.path.join(target_dir, folder_name)
+    try:
+        shutil.rmtree(delete_folder)
+        print(delete_folder + ' folder deleted successfully.')
+    except FileNotFoundError:
+        print('Target folder not found.')
+    except Exception as e:
+        print('Error deleting folder:', e)

--- a/core_automation/modules/versions.py
+++ b/core_automation/modules/versions.py
@@ -5,6 +5,7 @@
 import re
 import git
 
+
 # Determine current branch name from active repo
 def get_branch_name():
     repo = git.Repo(search_parent_directories=True)
@@ -20,14 +21,15 @@ def get_product_version(branch_name):
 
 # Determine target Strimzi release number based on product version (which we extract from branch name)
 def get_target_strimzi_version(product_version):
-    strimzi_minor_version = 2 * (product_version - 26) + 38
+    # account for 26-dev branch
+    strimzi_minor_version = 2 * (product_version - 26) + 43
     strimzi_version = f"0.{strimzi_minor_version}.0"
     return strimzi_version
 
 
 # Determine latest Kafka release number based on product version (which we extract from branch name)
 def get_kafka_version_to_replace(product_version):
-    strimzi_minor_version = (product_version + 10)
+    strimzi_minor_version = (product_version + 11)
     strimzi_version = f"{strimzi_minor_version / 10}"
     return strimzi_version
 
@@ -35,11 +37,18 @@ def get_kafka_version_to_replace(product_version):
 # Determine target Kafka Version
 def get_kafka_version_replacement(product_version):
     result = round(float(get_kafka_version_to_replace(product_version)) + 0.1, 1)
-    print("target Kafka version:" + str(result))
     return result
 
 
-# Determine target Kafka Version
-def get_target_release_version(kafka_version):
-    print("target release version:" + kafka_version)
+# Determine target Streams Version
+def get_target_streams_minor_version():
+    kafka_version = str(get_kafka_version_replacement(get_product_version(get_branch_name())))
+    kafka_version = "2" + kafka_version[1:]  # Replace the first digit with 2
     return kafka_version
+
+
+def get_target_micro_release_version():
+    release_version = get_target_streams_minor_version()
+    if not release_version.endswith(".0"):
+        release_version += ".0"  # Add .0 if it's not already there
+    return release_version

--- a/core_automation/tests/__init__.py
+++ b/core_automation/tests/__init__.py
@@ -1,2 +1,1 @@
 # core_automation/__init__.py
-

--- a/core_automation/tests/resources/test.05-Deployment-strimzi-topic-operator.yaml
+++ b/core_automation/tests/resources/test.05-Deployment-strimzi-topic-operator.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-topic-operator
+  template:
+    metadata:
+      labels:
+        name: strimzi-topic-operator
+        com.company: Red_Hat
+        rht.prod_name: Red_Hat_Application_Foundations
+        rht.prod_ver: 2024.Q3
+        rht.comp: AMQ_Streams
+        rht.comp_ver: "2.8"
+        rht.subcomp: topic-operator
+        rht.subcomp_t: infrastructure
+    spec:
+      serviceAccountName: strimzi-topic-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 5Mi
+      containers:
+        - name: strimzi-topic-operator
+          image: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
+          env:
+            - name: STRIMZI_RESOURCE_LABELS
+              value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: STRIMZI_ZOOKEEPER_CONNECT
+              value: my-cluster-zookeeper-client:2181
+            - name: STRIMZI_ZOOKEEPER_SESSION_TIMEOUT_MS
+              value: "18000"
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_TOPIC_METADATA_MAX_ATTEMPTS
+              value: "6"
+            - name: STRIMZI_LOG_LEVEL
+              value: INFO
+            - name: STRIMZI_TLS_ENABLED
+              value: "false"
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 500m
+            requests:
+              memory: 256Mi
+              cpu: 100m
+  strategy:
+    type: Recreate

--- a/core_automation/tests/resources/test.05-Deployment-strimzi-user-operator.yaml
+++ b/core_automation/tests/resources/test.05-Deployment-strimzi-user-operator.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-user-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-user-operator
+  template:
+    metadata:
+      labels:
+        name: strimzi-user-operator
+        com.company: Red_Hat
+        rht.prod_name: Red_Hat_Application_Foundations
+        rht.prod_ver: 2024.Q3
+        rht.comp: AMQ_Streams
+        rht.comp_ver: "2.8"
+        rht.subcomp: user-operator
+        rht.subcomp_t: infrastructure
+    spec:
+      serviceAccountName: strimzi-user-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 5Mi
+      containers:
+        - name: strimzi-user-operator
+          image: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
+              value: my-cluster-kafka-bootstrap:9092
+            - name: STRIMZI_LABELS
+              value: "strimzi.io/cluster=my-cluster"
+            - name: STRIMZI_CA_CERT_NAME
+              value: my-cluster-clients-ca-cert
+            - name: STRIMZI_CA_KEY_NAME
+              value: my-cluster-clients-ca
+            - name: STRIMZI_ACLS_ADMIN_API_SUPPORTED
+              value: "true"
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_LOG_LEVEL
+              value: INFO
+            - name: STRIMZI_GC_LOG_ENABLED
+              value: "true"
+            - name: STRIMZI_CA_VALIDITY
+              value: "365"
+            - name: STRIMZI_CA_RENEWAL
+              value: "30"
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: 500m
+            requests:
+              memory: 256Mi
+              cpu: 100m
+  strategy:
+    type: Recreate

--- a/core_automation/tests/resources/test.060-Deployment-strimzi-cluster-operator.yaml
+++ b/core_automation/tests/resources/test.060-Deployment-strimzi-cluster-operator.yaml
@@ -1,0 +1,1923 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+      strimzi.io/kind: cluster-operator
+  template:
+    metadata:
+      labels:
+        name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
+        com.company: Red_Hat
+        rht.prod_name: Red_Hat_Application_Foundations
+        rht.prod_ver: 2024.Q3
+        rht.comp: AMQ_Streams
+        rht.comp_ver: '2.8'
+        rht.subcomp: cluster-operator
+        rht.subcomp_t: infrastructure
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: co-config-volume
+          configMap:
+            name: strimzi-cluster-operator
+      containers:
+        - name: strimzi-cluster-operator
+          image: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+          ports:
+            - containerPort: 8080
+              name: http
+          args:
+            - /opt/strimzi/bin/cluster_operator_run.sh
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
+            - name: co-config-volume
+              mountPath: /opt/strimzi/custom-config/
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_OPERATION_TIMEOUT_MS
+              value: "300000"
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_CONNECT_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+              value: registry.redhat.io/amq-streams/bridge-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_MAVEN_BUILDER
+              value: registry.redhat.io/ubi8/openjdk-17:1.16
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FEATURE_GATES
+              value: ""
+            - name: STRIMZI_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+              value: "strimzi-cluster-operator"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/scheme=http
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/scheme=http
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/path=/
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/scheme=http
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/description-path=/openapi
+                discovery.3scale.net/port=8080
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 384Mi
+            requests:
+              cpu: 200m
+              memory: 384Mi

--- a/core_automation/tests/resources/test.060-Deployment-strimzi-drain-cleaner-openshift.yaml
+++ b/core_automation/tests/resources/test.060-Deployment-strimzi-drain-cleaner-openshift.yaml
@@ -1,0 +1,226 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-cluster-operator
+      strimzi.io/kind: cluster-operator
+  template:
+    metadata:
+      labels:
+        name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
+        com.company: Red_Hat
+        rht.prod_name: Red_Hat_Application_Foundations
+        rht.prod_ver: 2024.Q3
+        rht.comp: AMQ_Streams
+        rht.comp_ver: '2.8'
+        rht.subcomp: drain-cleaner
+        rht.subcomp_t: application
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      volumes:
+        - name: strimzi-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: co-config-volume
+          configMap:
+            name: strimzi-cluster-operator
+      containers:
+        - name: strimzi-cluster-operator
+          image: registry.redhat.io/amq-streams/drain-cleaner-rhel9:2.8.0
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: strimzi-tmp
+              mountPath: /tmp
+            - name: co-config-volume
+              mountPath: /opt/strimzi/custom-config/
+          env:
+            - name: STRIMZI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+              value: "120000"
+            - name: STRIMZI_OPERATION_TIMEOUT_MS
+              value: "300000"
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_CONNECT_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
+              value: |-
+                3.7.0=registry.redhat.io/amq-streams/kafka-37-rhel9:2.8.0
+                3.8.0=registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+              value: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
+            - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
+              value: registry.redhat.io/amq-streams/bridge-rhel9:2.8.0
+            - name: STRIMZI_DEFAULT_MAVEN_BUILDER
+              value: registry.redhat.io/ubi8/openjdk-17:1.16
+            - name: STRIMZI_OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_FEATURE_GATES
+              value: ""
+            - name: STRIMZI_LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAME
+              value: "strimzi-cluster-operator"
+            - name: STRIMZI_LEADER_ELECTION_LEASE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: STRIMZI_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_LABELS
+              value: discovery.3scale.net=true
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_SERVICE_ANNOTATIONS
+              value: |-
+                discovery.3scale.net/path=/
+                discovery.3scale.net/scheme=http
+                discovery.3scale.net/port=8080
+                discovery.3scale.net/description-path=/openapi
+            - name: STRIMZI_CUSTOM_KAFKA_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-connect
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_CONNECT_BUILD_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka--connect-build
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_ZOOKEEPER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=zookeeper
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_ENTITY_OPERATOR_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=entity-operator
+                rht.subcomp_t=infrastructure
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER2_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-mirror-maker2
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_MIRROR_MAKER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-broker
+                rht.subcomp_t=application
+            - name: TRIMZI_CUSTOM_CRUISE_CONTROL_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=cruise-control
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_BRIDGE_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=kafka-bridge
+                rht.subcomp_t=application
+            - name: STRIMZI_CUSTOM_KAFKA_EXPORTER_LABELS
+              value: |-
+                com.company=Red_Hat
+                rht.prod_name=Red_Hat_Application_Foundations
+                rht.prod_ver=2024.Q3
+                rht.comp=AMQ_Streams
+                rht.comp_ver=2.8
+                rht.subcomp=afka-exporter
+                rht.subcomp_t=application
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 384Mi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+          command:
+            - /application
+            - -Dquarkus.http.host=0.0.0.0
+            - --kafka
+            - --zookeeper

--- a/core_automation/tests/test_backport_examples.py
+++ b/core_automation/tests/test_backport_examples.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
 """########################################################
- FILE: test_backport.py
+ FILE: test_backport_examples.py
 ########################################################"""
 import os
-import unittest
 from unittest.mock import patch
-from core_automation.modules import backport_examples
+import unittest
+
+from core_automation.modules.backport_examples import compare_directory_files, update_example_dir_readme, \
+    delete_created_upstream_resources, delete_file, create_release_url_for_zips
 
 
 class TestBackportExampleAutomation(unittest.TestCase):
 
     def test_create_release_url_for_zips(self):
-        target_strimzi_version = "0.38.0"
-        release_url = backport_examples.create_release_url_for_zips(target_strimzi_version)
-        expected_url = "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.38.0/strimzi-0.38.0.zip"
+        target_strimzi_version = "0.43.0"
+        release_url = create_release_url_for_zips(target_strimzi_version)
+        expected_url = "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.43.0/strimzi-0.43.0.zip"
         self.assertEqual(release_url, expected_url)
 
     @patch("os.listdir")
@@ -23,36 +25,38 @@ class TestBackportExampleAutomation(unittest.TestCase):
             ["file1.txt", "file2.txt", "file3.txt"]
         ]
         with patch("builtins.print") as mock_print:
-            backport_examples.compare_directory_files("dir_path1", "dir_path2")
-        # Asserting that the print calls contain the expected output
+            compare_directory_files("dir_path1", "dir_path2")
+
         mock_print.assert_any_call("Number of files in dir_path1: 3")
         mock_print.assert_any_call("Number of files in dir_path2: 3")
         mock_print.assert_any_call("Both directories have the same number of files.")
 
     def test_string_replacement(self):
-        examples_dir = "examples"
+        examples_dir = "/home/owencorrigan/Documents/Work_Repos/amqstreams-1-openshift-image/examples"
         file_name = "README.md"
-        backport_examples.update_example_dir_readme(examples_dir, file_name)
-        with open("../../examples/README.md", 'r') as f:
+
+        update_example_dir_readme(examples_dir, file_name)
+        with open("../strimzi-0.43.0/README.md", 'r') as f:
             content = f.read()
         self.assertIn("AMQ Streams", content)
 
+
     def test_excluded_directory(self):
-        directory = "strimzi-0.38.0/examples"
-        excluded_directory = "strimzi-0.38.0/examples/kafka-mirror-maker-2"
-        backport_examples.delete_created_upstream_resources(directory)
+        directory = "strimzi-0.43.0/examples"
+        excluded_directory = "strimzi-0.43.0/examples/kafka-mirror-maker-2"
+        delete_created_upstream_resources(directory)
         self.assertFalse(os.path.exists(excluded_directory))
 
     def test_deleted_files(self):
-        file_path1 = "strimzi-0.38.0/examples/security/keycloak-authorization/README.md"
-        file_path2 = "strimzi-0.38.0/examples/connect/kafka-connect-build.yaml"
-        backport_examples.delete_file(file_path1, file_path2)
+        file_path1 = "strimzi-0.43.0/examples/security/keycloak-authorization/README.md"
+        file_path2 = "strimzi-0.43.0/examples/connect/kafka-connect-build.yaml"
+        delete_file(file_path1, file_path2)
         self.assertFalse(os.path.exists(file_path1))
         self.assertFalse(os.path.exists(file_path2))
 
     def test_deleted_upstream_resource(self):
-        directory = "strimzi-0.38.0"
-        backport_examples.delete_created_upstream_resources(directory)
+        directory = "strimzi-0.43.0"
+        delete_created_upstream_resources(directory)
         self.assertFalse(os.path.exists(directory))
 
 

--- a/core_automation/tests/test_backport_install.py
+++ b/core_automation/tests/test_backport_install.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""########################################################
+ FILE: test_backport_install.py
+########################################################"""
+import unittest
+from datetime import datetime
+
+import yaml
+
+from core_automation.modules.backport_install import (update_deployment,
+                                                      update_cluster_operator_deployment,
+                                                      get_current_year_and_quarter, get_last_year_and_quarter)
+
+
+def _load_yaml_data(file_path):
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
+
+
+class TestBackportExampleAutomation(unittest.TestCase):
+    RESOURCES_PATH = "/home/owencorrigan/Documents/Work_Repos/amqstreams-1-openshift-image/core_automation/tests/resources/"
+    COMMON_REGISTRY_URL = "registry.redhat.io/amq-streams/"
+    EXPECTED_NEWEST_KAFKA_VERSION = "3.8.0"
+    EXPECTED_UPGRADE_KAFKA_VERSION = "3.7.0"
+    RHT_COMP_VERSION = "2.8"
+    STRIMZI_VERSION = "2.8.0"
+    YEAR_AND_QUARTER_VERSION = "2024.Q3"
+
+    def setUp(self):
+        self.USER_OPERATOR_DEPLOYMENT_FILE = self.RESOURCES_PATH + "test.05-Deployment-strimzi-user-operator.yaml"
+        self.TOPIC_OPERATOR_DEPLOYMENT_FILE = self.RESOURCES_PATH + "test.05-Deployment-strimzi-topic-operator.yaml"
+        self.CLUSTER_OPERATOR_DEPLOYMENT_FILE = self.RESOURCES_PATH + "test.060-Deployment-strimzi-cluster-operator.yaml"
+        self.DRAIN_CLEANER_OPENSHIFT_DEPLOYMENT_FILE = self.RESOURCES_PATH + "test.060-Deployment-strimzi-drain-cleaner-openshift.yaml"
+
+    def _assert_yaml_fields(self, yaml_data, expected_fields):
+        image_field = yaml_data["spec"]["template"]["spec"]["containers"][0]["image"]
+        label_field = yaml_data["spec"]["template"]["metadata"]["labels"]
+        self.assertEqual(image_field, expected_fields)
+        self.assertEqual(label_field["rht.comp_ver"], self.RHT_COMP_VERSION)
+        self.assertEqual(label_field["rht.prod_ver"], self.YEAR_AND_QUARTER_VERSION)
+
+    def test_update_cluster_operator_deployment(self):
+        update_cluster_operator_deployment(self.CLUSTER_OPERATOR_DEPLOYMENT_FILE, self.STRIMZI_VERSION)
+        yaml_data = _load_yaml_data(self.CLUSTER_OPERATOR_DEPLOYMENT_FILE)
+        env_field = yaml_data["spec"]["template"]["spec"]["containers"][0]["env"][7]["value"]
+        expected_image = f"{self.COMMON_REGISTRY_URL}strimzi-rhel9-operator:{self.STRIMZI_VERSION}"
+        self.assertIn(f"registry.redhat.io/amq-streams/kafka-38-rhel9:{self.STRIMZI_VERSION}", env_field)
+        self._assert_yaml_fields(yaml_data, expected_image)
+
+    def test_update_user_deployment(self):
+        update_deployment(self.USER_OPERATOR_DEPLOYMENT_FILE, self.STRIMZI_VERSION, "user-operator", "infrastructure")
+        yaml_data = _load_yaml_data(self.USER_OPERATOR_DEPLOYMENT_FILE)
+        expected_image = f"{self.COMMON_REGISTRY_URL}strimzi-rhel9-operator:{self.STRIMZI_VERSION}"
+        self._assert_yaml_fields(yaml_data, expected_image)
+
+    def test_update_topic_deployment(self):
+        update_deployment(self.TOPIC_OPERATOR_DEPLOYMENT_FILE, self.STRIMZI_VERSION, "topic-operator", "infrastructure")
+        yaml_data = _load_yaml_data(self.TOPIC_OPERATOR_DEPLOYMENT_FILE)
+        expected_image = f"{self.COMMON_REGISTRY_URL}strimzi-rhel9-operator:{self.STRIMZI_VERSION}"
+        self._assert_yaml_fields(yaml_data, expected_image)
+
+    def test_update_drain_cleaner_deployment(self):
+        update_deployment(self.DRAIN_CLEANER_OPENSHIFT_DEPLOYMENT_FILE, self.STRIMZI_VERSION, "drain-cleaner",
+                          "application")
+        yaml_data = _load_yaml_data(self.DRAIN_CLEANER_OPENSHIFT_DEPLOYMENT_FILE)
+        expected_image = f"{self.COMMON_REGISTRY_URL}drain-cleaner-rhel9:{self.STRIMZI_VERSION}"
+        self._assert_yaml_fields(yaml_data, expected_image)
+
+    def test_get_last_year_and_quarter(self):
+        current_date = datetime.now()
+        current_year = current_date.year
+        current_month = current_date.month
+
+        # Calculate expected year and quarter based on current date
+        if current_month <= 3:
+            expected_year = current_year - 1
+            expected_quarter = 4
+        elif current_month <= 6:
+            expected_year = current_year
+            expected_quarter = 1
+        elif current_month <= 9:
+            expected_year = current_year
+            expected_quarter = 2
+        else:
+            expected_year = current_year
+            expected_quarter = 3
+
+        year, quarter = get_last_year_and_quarter()
+        self.assertEqual(year, expected_year)
+        self.assertEqual(quarter, expected_quarter)
+
+    def test_get_current_year_and_quarter(self):
+        current_date = datetime.now()
+        current_year = current_date.year
+        current_month = current_date.month
+
+        if current_month <= 3:
+            expected_year = current_year
+            expected_quarter = 1
+        elif current_month <= 6:
+            expected_year = current_year
+            expected_quarter = 2
+        elif current_month <= 9:
+            expected_year = current_year
+            expected_quarter = 3
+        else:
+            expected_year = current_year
+            expected_quarter = 4
+
+        year, quarter = get_current_year_and_quarter()
+        self.assertEqual(year, expected_year)
+        self.assertEqual(quarter, expected_quarter)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/core_automation/tests/test_versions.py
+++ b/core_automation/tests/test_versions.py
@@ -19,35 +19,36 @@ class TestVersions(unittest.TestCase):
         actual_product_version = versions.get_product_version(branch_name)
         self.assertEqual(actual_product_version, expected_product_version)
 
+# working off 26-dev branch, hence the discrepancy between 26 and 28
     def test_get_target_strimzi_release(self):
         product_version = 26
-        expected_strimzi_version = "0.38.0"
+        expected_strimzi_version = "0.43.0"
         actual_strimzi_version = versions.get_target_strimzi_version(product_version)
         self.assertEqual(actual_strimzi_version, expected_strimzi_version)
 
-        product_version = 27
-        expected_strimzi_version = "0.40.0"
+        product_version = 25
+        expected_strimzi_version = "0.41.0"
         actual_strimzi_version = versions.get_target_strimzi_version(product_version)
         self.assertEqual(actual_strimzi_version, expected_strimzi_version)
 
     def test_get_latest_kafka_release(self):
         product_version = 26
-        expected_kafka_version = "3.6"
-        actual_kafka_version = versions.get_kafka_version_to_replace(product_version)
-        self.assertEqual(actual_kafka_version, expected_kafka_version)
-
-        product_version = 27
         expected_kafka_version = "3.7"
         actual_kafka_version = versions.get_kafka_version_to_replace(product_version)
         self.assertEqual(actual_kafka_version, expected_kafka_version)
 
+        product_version = 27
+        expected_kafka_version = "3.8"
+        actual_kafka_version = versions.get_kafka_version_to_replace(product_version)
+        self.assertEqual(actual_kafka_version, expected_kafka_version)
+
     def test_get_target_kafka_version(self):
-        product_version = 26
+        product_version = 25
         expected_kafka_version = 3.7
         actual_kafka_version = versions.get_kafka_version_replacement(product_version)
         self.assertEqual(actual_kafka_version, expected_kafka_version)
 
-        product_version = 27
+        product_version = 26
         expected_kafka_version = 3.8
         actual_kafka_version = versions.get_kafka_version_replacement(product_version)
         self.assertEqual(actual_kafka_version, expected_kafka_version)


### PR DESCRIPTION
These Python scripts download a zip of the latest upstream Strimzi and backports the files in the Install and Examples drectories for downstream Streams for Apache Kafka.