### PR TITLE
Renaming streams-ocp zip files

### DIFF
--- a/kafka/modules/kafka/3.7.0/install.sh
+++ b/kafka/modules/kafka/3.7.0/install.sh
@@ -7,8 +7,8 @@ LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
 # Copy contents of zip without the root dir
-TMP=$(zipinfo -1  ${SOURCES_DIR}/streams-ocp-*.zip | grep -oE '^[^/]+' | uniq)
-unzip ${SOURCES_DIR}/streams-ocp-*.zip
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka-ocp-*.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka-ocp-*.zip
 mv ${TMP}/* ${KAFKA_HOME}/
 
 mkdir -p ${PRODUCT_LICENSE_DIR}/kafka

--- a/kafka/modules/kafka/3.7.0/module.yaml
+++ b/kafka/modules/kafka/3.7.0/module.yaml
@@ -9,7 +9,7 @@ envs:
 
 artifacts:
   - md5: 38e81cb44d309caaf726c0ff283733c8
-    name: streams-ocp-previous.zip
+    name: kafka-ocp-previous.zip
 
 modules:
   install:

--- a/kafka/modules/kafka/3.8.0/install.sh
+++ b/kafka/modules/kafka/3.8.0/install.sh
@@ -7,8 +7,8 @@ LICENSE_DIR=/root/licenses
 PRODUCT_LICENSE_DIR=${LICENSE_DIR}/${COM_REDHAT_COMPONENT}
 
 # Copy contents of zip without the root dir
-TMP=$(zipinfo -1  ${SOURCES_DIR}/streams-ocp-*.zip | grep -oE '^[^/]+' | uniq)
-unzip ${SOURCES_DIR}/streams-ocp-*.zip
+TMP=$(zipinfo -1  ${SOURCES_DIR}/kafka-ocp-*.zip | grep -oE '^[^/]+' | uniq)
+unzip ${SOURCES_DIR}/kafka-ocp-*.zip
 mv ${TMP}/* ${KAFKA_HOME}/
 
 mkdir -p ${PRODUCT_LICENSE_DIR}/kafka

--- a/kafka/modules/kafka/3.8.0/module.yaml
+++ b/kafka/modules/kafka/3.8.0/module.yaml
@@ -9,7 +9,7 @@ envs:
 
 artifacts:
   - md5: b34d42de42a186d574abe4500603cb2e
-    name: streams-ocp-current.zip
+    name: kafka-ocp-current.zip
 
 modules:
   install:


### PR DESCRIPTION
Renaming `streams-ocp` to `kafka-ocp` zip files to be consistent with artifacts produced by PNC.