### PR TITLE
Remove stunnel from Kafka scripts

### DIFF
--- a/kafka/kafka-3.7.0/image.yaml
+++ b/kafka/kafka-3.7.0/image.yaml
@@ -58,7 +58,6 @@ packages:
     - nmap-ncat
     - openssl
     - hostname
-    - stunnel
     - net-tools
     - bind-utils
     - tini

--- a/kafka/kafka-3.8.0/image.yaml
+++ b/kafka/kafka-3.8.0/image.yaml
@@ -58,7 +58,6 @@ packages:
     - nmap-ncat
     - openssl
     - hostname
-    - stunnel
     - net-tools
     - bind-utils
     - tini

--- a/kafka/modules/kafka/base/install.sh
+++ b/kafka/modules/kafka/base/install.sh
@@ -11,7 +11,6 @@ SCRIPTS_DIR=${SCRIPT_DIR}/scripts
 useradd -r -m -u 1001 -g 0 strimzi
 
 mkdir $KAFKA_HOME
-mkdir $STUNNEL_HOME
 mkdir $S2I_HOME
 mkdir $KAFKA_EXPORTER_HOME
 mkdir $CRUISE_CONTROL_HOME
@@ -30,9 +29,6 @@ unzip ${SOURCES_DIR}/strimzi-kafka-scripts.zip -d ${SCRIPTS_DIR}
 # NOTE: kafka folder alredy contains the s2i (so no need for a specific cp command)
 cp -r ${SCRIPTS_DIR}/kafka/* ${KAFKA_HOME}/
 chmod -R 755 ${KAFKA_HOME}
-
-cp -r ${SCRIPTS_DIR}/stunnel/* ${STUNNEL_HOME}/
-chmod -R 755 ${STUNNEL_HOME}
 
 mv /usr/bin/kafka_exporter ${KAFKA_EXPORTER_HOME}/
 cp -r ${SCRIPTS_DIR}/kafka-exporter/* ${KAFKA_EXPORTER_HOME}/

--- a/kafka/modules/kafka/base/module.yaml
+++ b/kafka/modules/kafka/base/module.yaml
@@ -6,8 +6,6 @@ version: 2.8.0
 envs:
   - name: "KAFKA_HOME"
     value: "/opt/kafka"
-  - name: "STUNNEL_HOME"
-    value: "/opt/stunnel"
   - name: "S2I_HOME"
     value: "/opt/kafka/s2i"
   - name: "KAFKA_EXPORTER_HOME"


### PR DESCRIPTION
Stunnel was removed from upstream repo. Having it in `install.sh` is causing the Kafka image builds to fail.