### PR TITLE
Enable installation of unreleased RPMs

### DIFF
--- a/kafka/kafka-3.7.0/image.yaml
+++ b/kafka/kafka-3.7.0/image.yaml
@@ -76,7 +76,10 @@ osbs:
     gating_file: gating.yaml
     container:
       compose:
+        packages:
+          - kafka_exporter
         pulp_repos: true
+        include_unpublished_pulp_repos: true
       platforms:
         only:
         - x86_64

--- a/kafka/kafka-3.8.0/image.yaml
+++ b/kafka/kafka-3.8.0/image.yaml
@@ -76,7 +76,10 @@ osbs:
     gating_file: gating.yaml
     container:
       compose:
+        packages:
+          - kafka_exporter
         pulp_repos: true
+        include_unpublished_pulp_repos: true
       platforms:
         only:
         - x86_64


### PR DESCRIPTION
This configuration allows us to install candidate release RPM builds into our container images before those RPM builds are released to production pulp repos. This allows us to build and release all of our components:

- artifacts
- RPMs
- containers

At the same time. Up until now, we have always had to release RPMs to production repos ahead of our actual GA release.