### PR TITLE
Revert securityContext yaml fields

### DIFF
--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -35,8 +35,6 @@ spec:
       containers:
         - name: strimzi-cluster-operator
           image: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0
-          securityContext:
-            readOnlyRootFilesystem: true
           ports:
             - containerPort: 8080
               name: http

--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -1225,8 +1225,6 @@ spec:
               containers:
                 - name: strimzi-cluster-operator
                   image: registry.redhat.io/amq-streams/strimzi-rhel9-operator:2.8.0-0
-                  securityContext:
-                    readOnlyRootFilesystem: true
                   ports:
                     - containerPort: 8080
                       name: http


### PR DESCRIPTION
The `securtityContext` field is to be removed from Cluster Operator Deployment and OLM Deployment yamls for the current CR.

 