### PR TITLE
Update ocp to 4.12

### DIFF
--- a/operator-metadata/image.yaml
+++ b/operator-metadata/image.yaml
@@ -29,7 +29,7 @@ labels:
   - name: "com.redhat.delivery.operator.bundle"
     value: "true"
   - name: "com.redhat.openshift.versions"
-    value: "v4.8"
+    value: "v4.12"
   - name: "maintainer"
     value: "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
 

--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -838,7 +838,7 @@ spec:
     **Red Hat AMQ Streams** is a massively scalable, distributed, and high performance data streaming platform based on the Apache Kafka® project.
     AMQ Streams provides an event streaming backbone that allows microservices and other application components to exchange data with extremely high throughput and low latency.
 
-    **From the 2.5.2 release, AMQ Streams supports only OCP 4.10 to 4.13!
+    **From the 2.5.2 release, AMQ Streams supports only OCP 4.12 to 4.16!
 
     **The core capabilities include:**
     * A pub/sub messaging model, similar to a traditional enterprise messaging system, in which application components publish and consume events to/from an ordered stream

--- a/operator-metadata/metadata/annotations.yaml
+++ b/operator-metadata/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10
+  com.redhat.openshift.versions: v4.12
   operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.bundle.channels.v1: amq-streams-2.5.x,amq-streams-lts
   operators.operatorframework.io.bundle.manifests.v1: manifests/


### PR DESCRIPTION
Updating supported OCP versions to corrolate with the release dashboard versions. 4.12 - 4.16