### PR TITLE
update test image to ocp versions 4.12

### DIFF
--- a/operator-metadata/automation/tests/resources/test.image.yaml
+++ b/operator-metadata/automation/tests/resources/test.image.yaml
@@ -29,7 +29,7 @@ labels:
   - name: "com.redhat.delivery.operator.bundle"
     value: "true"
   - name: "com.redhat.openshift.versions"
-    value: "v4.8"
+    value: "v4.12"
   - name: "maintainer"
     value: "AMQ Streams Engineering <amq-streams-dev@redhat.com>"
 


### PR DESCRIPTION
Update test image to ocp versions 4.12 to corrolate with the changes made in `operator-metadata` 