### PR TITLE
Remove Entity Operator TLS sidecar image configuration from YAMLs

### DIFF
--- a/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/060-Deployment-strimzi-cluster-operator.yaml
@@ -54,8 +54,6 @@ spec:
               value: "120000"
             - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "300000"
-            - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
               value: registry.redhat.io/amq-streams/kafka-38-rhel9:2.8.0
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE

--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -1244,10 +1244,6 @@ spec:
                       value: "120000"
                     - name: STRIMZI_OPERATION_TIMEOUT_MS
                       value: "300000"
-                    - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.annotations['kafka-current-image']
                     - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
                       valueFrom:
                         fieldRef:


### PR DESCRIPTION
Removing the Entity OPerator TLS sidecar image configuration from the YAML Deployment and OLM deployment.