### PR TITLE
Fix 2.5.2 lts bundles skip range

### DIFF
--- a/operator-metadata/automation/modules/bundle_automation.py
+++ b/operator-metadata/automation/modules/bundle_automation.py
@@ -283,7 +283,7 @@ class BundleAutomation:
 
         csv_data = csv_data.replace(old_bundle_version, new_bundle_version)
 
-        start_interval = BundleAutomation.get_start_interval(new_bundle_version)
+        start_interval = "2.2.0-0"
         csv_data = re.sub(r"olm.skipRange: '>=\d.\d.\d-\d <\d.\d.\d-\d'",
                           "olm.skipRange: '>=" + start_interval + " <" + new_bundle_version + "'", csv_data)
         csv_data = re.sub(r'replaces: amqstreams.v.*..*..*', 'replaces: amqstreams.v' + old_bundle_version, csv_data)

--- a/operator-metadata/manifests/bundle.clusterserviceversion.yaml
+++ b/operator-metadata/manifests/bundle.clusterserviceversion.yaml
@@ -380,7 +380,7 @@ metadata:
       ["Red Hat AMQ", "Red Hat Application Foundations"]
     operators.operatorframework.io/internal-objects: |-
       ["strimzipodsets.core.strimzi.io"]
-    olm.skipRange: '>=2.4.0-0 <2.5.2-5'
+    olm.skipRange: '>=2.2.0-0 <2.5.2-6'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported


### PR DESCRIPTION
Fix the metadata in the 2.5 and 2.9 Streams bundles to enable upgrade from the previous LTS version and ship them to the Streams LTS OLM channel, "amq-streams-lts"